### PR TITLE
Improve setLayerType

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/view/OverlayView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/OverlayView.java
@@ -172,7 +172,8 @@ public class OverlayView extends View {
     }
 
     protected void init() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2 &&
+		        Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             setLayerType(LAYER_TYPE_SOFTWARE, null);
         }
     }


### PR DESCRIPTION
The best way to work around the problem is calling ```setLayerType(View.LAYER_TYPE_SOFTWARE, null)``` only when you are running on API from 11 to 17

UnsupportedOperationException should never be thrown on API >= 18.
See [Unsupported Drawing Operations](http://developer.android.com/guide/topics/graphics/hardware-accel.html#unsupported)


Source : http://stackoverflow.com/a/30354461