### PR TITLE
Remove synthetic accessor methods

### DIFF
--- a/sample/src/main/java/com/yalantis/ucrop/sample/SampleActivity.java
+++ b/sample/src/main/java/com/yalantis/ucrop/sample/SampleActivity.java
@@ -40,7 +40,8 @@ public class SampleActivity extends BaseActivity {
     private EditText mEditTextMaxWidth, mEditTextMaxHeight;
     private CheckBox mCheckBoxMaxSize;
     private SeekBar mSeekBarQuality;
-    private TextView mTextViewQuality;
+
+    TextView mTextViewQuality;
 
     private Uri mDestinationUri;
 
@@ -129,7 +130,7 @@ public class SampleActivity extends BaseActivity {
         });
     }
 
-    private void pickFromGallery() {
+    void pickFromGallery() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN // Permission was added in API Level 16
                 && ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
                 != PackageManager.PERMISSION_GRANTED) {

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
@@ -43,14 +43,15 @@ public class UCropActivity extends AppCompatActivity {
 
     private static final String TAG = "UCropActivity";
 
-    private static final int SCALE_WIDGET_SENSITIVITY_COEFFICIENT = 15000;
-    private static final int ROTATE_WIDGET_SENSITIVITY_COEFFICIENT = 42;
+    static final int SCALE_WIDGET_SENSITIVITY_COEFFICIENT = 15000;
+    static final int ROTATE_WIDGET_SENSITIVITY_COEFFICIENT = 42;
 
-    private GestureCropImageView mGestureCropImageView;
+    List<ViewGroup> mCropAspectRatioViews = new ArrayList<>();
+    GestureCropImageView mGestureCropImageView;
+
     private OverlayView mOverlayView;
     private ViewGroup mWrapperStateAspectRatio, mWrapperStateRotate, mWrapperStateScale;
     private ViewGroup mLayoutAspectRatio, mLayoutRotate, mLayoutScale;
-    private List<ViewGroup> mCropAspectRatioViews = new ArrayList<>();
     private TextView mTextViewRotateAngle, mTextViewScalePercent;
 
     private Uri mOutputUri;
@@ -327,24 +328,24 @@ public class UCropActivity extends AppCompatActivity {
                 });
     }
 
-    private void setAngleText(float angle) {
+    void setAngleText(float angle) {
         if (mTextViewRotateAngle != null) {
             mTextViewRotateAngle.setText(String.format("%.1f°", angle));
         }
     }
 
-    private void setScaleText(float scale) {
+    void setScaleText(float scale) {
         if (mTextViewScalePercent != null) {
             mTextViewScalePercent.setText(String.format("%d%%", (int) (scale * 100)));
         }
     }
 
-    private void resetRotation() {
+    void resetRotation() {
         mGestureCropImageView.postRotate(-mGestureCropImageView.getCurrentAngle());
         mGestureCropImageView.setImageToWrapCropBounds();
     }
 
-    private void rotateByAngle(int angle) {
+    void rotateByAngle(int angle) {
         mGestureCropImageView.postRotate(angle);
         mGestureCropImageView.setImageToWrapCropBounds();
     }
@@ -362,7 +363,7 @@ public class UCropActivity extends AppCompatActivity {
         setWidgetState(R.id.state_scale);
     }
 
-    private void setWidgetState(@IdRes int stateViewId) {
+    void setWidgetState(@IdRes int stateViewId) {
         mWrapperStateAspectRatio.setSelected(stateViewId == R.id.state_aspect_ratio);
         mWrapperStateRotate.setSelected(stateViewId == R.id.state_rotate);
         mWrapperStateScale.setSelected(stateViewId == R.id.state_scale);

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
@@ -32,7 +32,7 @@ public abstract class CropImageView extends TransformImageView {
     public static final float SOURCE_IMAGE_ASPECT_RATIO = 0f;
     public static final float DEFAULT_ASPECT_RATIO = SOURCE_IMAGE_ASPECT_RATIO;
 
-    private final RectF mCropRect = new RectF();
+    final RectF mCropRect = new RectF();
 
     private final Matrix mTempMatrix = new Matrix();
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/GestureCropImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/GestureCropImageView.java
@@ -13,13 +13,13 @@ import com.yalantis.ucrop.util.RotationGestureDetector;
  */
 public class GestureCropImageView extends CropImageView {
 
-    private static final int DOUBLE_TAP_ZOOM_DURATION = 200;
+    static final int DOUBLE_TAP_ZOOM_DURATION = 200;
 
     private ScaleGestureDetector mScaleDetector;
     private RotationGestureDetector mRotateDetector;
     private GestureDetector mGestureDetector;
 
-    private float mMidPntX, mMidPntY;
+    float mMidPntX, mMidPntY;
 
     private boolean mIsRotateEnabled = true, mIsScaleEnabled = true;
     private int mDoubleTapScaleSteps = 5;

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/UCropView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/UCropView.java
@@ -12,7 +12,7 @@ import com.yalantis.ucrop.R;
 public class UCropView extends FrameLayout {
 
     private final GestureCropImageView mGestureCropImageView;
-    private final OverlayView mViewOverlay;
+    final OverlayView mViewOverlay;
 
     public UCropView(Context context, AttributeSet attrs) {
         this(context, attrs, 0);


### PR DESCRIPTION
These are created when private fields/methods from the outer class are accessed from an inner class.
This patch removes 11 methods from the uCrop and 2 methods from sample.