### PR TITLE
Option to hide bottom controls

### DIFF
--- a/sample/src/main/java/com/yalantis/ucrop/sample/SampleActivity.java
+++ b/sample/src/main/java/com/yalantis/ucrop/sample/SampleActivity.java
@@ -41,6 +41,7 @@ public class SampleActivity extends BaseActivity {
     private CheckBox mCheckBoxMaxSize;
     private SeekBar mSeekBarQuality;
     private TextView mTextViewQuality;
+    private CheckBox mCheckBoxHideBottomControls;
 
     private Uri mDestinationUri;
 
@@ -106,6 +107,7 @@ public class SampleActivity extends BaseActivity {
         mEditTextMaxHeight = ((EditText) findViewById(R.id.edit_text_max_height));
         mSeekBarQuality = ((SeekBar) findViewById(R.id.seekbar_quality));
         mTextViewQuality = ((TextView) findViewById(R.id.text_view_quality));
+        mCheckBoxHideBottomControls = ((CheckBox) findViewById(R.id.checkbox_hide_bottom_controls));
 
         mRadioGroupAspectRatio.check(R.id.radio_dynamic);
         mEditTextRatioX.addTextChangedListener(mAspectRatioTextWatcher);
@@ -240,6 +242,8 @@ public class SampleActivity extends BaseActivity {
                 break;
         }
         options.setCompressionQuality(mSeekBarQuality.getProgress());
+
+        options.setHideBottomControls(mCheckBoxHideBottomControls.isChecked());
 
         /*
         If you want to configure how gestures work for all UCropActivity tabs

--- a/sample/src/main/res/layout/activity_sample.xml
+++ b/sample/src/main/res/layout/activity_sample.xml
@@ -234,19 +234,19 @@
                 android:layout_margin="5dp"
                 android:background="@color/colorAccent"/>
 
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:text="@string/label_ui"
-                    android:textAppearance="?android:textAppearanceSmall"/>
+                android:textAppearance="?android:textAppearanceSmall"/>
 
             <CheckBox
                 android:id="@+id/checkbox_hide_bottom_controls"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:text="@string/label_hide_bottom_ui_controls"
-                android:textAppearance="?android:textAppearanceMedium" />
+                android:textAppearance="?android:textAppearanceMedium"/>
 
         </LinearLayout>
 

--- a/sample/src/main/res/layout/activity_sample.xml
+++ b/sample/src/main/res/layout/activity_sample.xml
@@ -33,7 +33,7 @@
                 android:text="@string/app_name"
                 android:textColor="@color/colorAccent"
                 android:textSize="42sp"
-                android:textStyle="bold"/>
+                android:textStyle="bold" />
 
             <Button
                 android:id="@+id/button_crop"
@@ -41,15 +41,15 @@
                 android:layout_height="wrap_content"
                 android:text="@string/button_pick_amp_crop"
                 android:textAllCaps="true"
-                android:textColor="@android:color/white"
                 android:textAppearance="?android:textAppearanceMedium"
-                android:textStyle="bold"/>
+                android:textColor="@android:color/white"
+                android:textStyle="bold" />
 
             <View
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_margin="5dp"
-                android:background="@color/colorAccent"/>
+                android:background="@color/colorAccent" />
 
             <RadioGroup
                 android:id="@+id/radio_group_aspect_ratio"
@@ -61,7 +61,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:text="@string/label_aspect_ratio"
-                    android:textAppearance="?android:textAppearanceSmall"/>
+                    android:textAppearance="?android:textAppearanceSmall" />
 
                 <RadioButton
                     android:id="@+id/radio_dynamic"
@@ -69,21 +69,21 @@
                     android:layout_height="wrap_content"
                     android:text="@string/label_dynamic"
                     android:textAppearance="?android:textAppearanceMedium"
-                    tools:checked="true"/>
+                    tools:checked="true" />
 
                 <RadioButton
                     android:id="@+id/radio_origin"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/label_image_source"
-                    android:textAppearance="?android:textAppearanceMedium"/>
+                    android:textAppearance="?android:textAppearanceMedium" />
 
                 <RadioButton
                     android:id="@+id/radio_square"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/label_square"
-                    android:textAppearance="?android:textAppearanceMedium"/>
+                    android:textAppearance="?android:textAppearanceMedium" />
 
                 <LinearLayout
                     android:layout_width="140dp"
@@ -97,13 +97,13 @@
                         android:layout_weight="1"
                         android:gravity="center"
                         android:hint="x"
-                        android:inputType="numberDecimal"/>
+                        android:inputType="numberDecimal" />
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="to"
-                        tools:ignore="HardcodedText"/>
+                        tools:ignore="HardcodedText" />
 
                     <EditText
                         android:id="@+id/edit_text_ratio_y"
@@ -112,7 +112,7 @@
                         android:layout_weight="1"
                         android:gravity="center"
                         android:hint="y"
-                        android:inputType="numberDecimal"/>
+                        android:inputType="numberDecimal" />
 
                 </LinearLayout>
 
@@ -122,21 +122,21 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_margin="5dp"
-                android:background="@color/colorAccent"/>
+                android:background="@color/colorAccent" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:text="@string/label_max_cropped_image_size"
-                android:textAppearance="?android:textAppearanceSmall"/>
+                android:textAppearance="?android:textAppearanceSmall" />
 
             <CheckBox
                 android:id="@+id/checkbox_max_size"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/label_resize_image_to_max_size"
-                android:textAppearance="?android:textAppearanceMedium"/>
+                android:textAppearance="?android:textAppearanceMedium" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -150,13 +150,13 @@
                     android:layout_weight="1"
                     android:gravity="center"
                     android:hint="@string/label_width"
-                    android:inputType="number"/>
+                    android:inputType="number" />
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="x"
-                    tools:ignore="HardcodedText"/>
+                    tools:ignore="HardcodedText" />
 
                 <EditText
                     android:id="@+id/edit_text_max_height"
@@ -165,7 +165,7 @@
                     android:layout_weight="1"
                     android:gravity="center"
                     android:hint="@string/label_height"
-                    android:inputType="number"/>
+                    android:inputType="number" />
 
             </LinearLayout>
 
@@ -173,7 +173,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_margin="5dp"
-                android:background="@color/colorAccent"/>
+                android:background="@color/colorAccent" />
 
             <RadioGroup
                 android:id="@+id/radio_group_compression_settings"
@@ -185,7 +185,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:text="@string/label_compression_settings"
-                    android:textAppearance="?android:textAppearanceSmall"/>
+                    android:textAppearance="?android:textAppearanceSmall" />
 
                 <RadioButton
                     android:id="@+id/radio_jpeg"
@@ -194,7 +194,7 @@
                     android:text="JPEG"
                     android:textAppearance="?android:textAppearanceMedium"
                     tools:checked="true"
-                    tools:ignore="HardcodedText"/>
+                    tools:ignore="HardcodedText" />
 
                 <RadioButton
                     android:id="@+id/radio_png"
@@ -202,7 +202,7 @@
                     android:layout_height="wrap_content"
                     android:text="PNG"
                     android:textAppearance="?android:textAppearanceMedium"
-                    tools:ignore="HardcodedText"/>
+                    tools:ignore="HardcodedText" />
 
                 <RadioButton
                     android:id="@+id/radio_webp"
@@ -210,7 +210,7 @@
                     android:layout_height="wrap_content"
                     android:text="WEBP"
                     android:textAppearance="?android:textAppearanceMedium"
-                    tools:ignore="HardcodedText"/>
+                    tools:ignore="HardcodedText" />
 
                 <TextView
                     android:id="@+id/text_view_quality"
@@ -218,15 +218,35 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:textAppearance="?android:textAppearanceSmall"
-                    tools:text="Quality: 90"/>
+                    tools:text="Quality: 90" />
 
                 <SeekBar
                     android:id="@+id/seekbar_quality"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    tools:progress="90"/>
+                    tools:progress="90" />
 
             </RadioGroup>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_margin="5dp"
+                android:background="@color/colorAccent" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/label_ui"
+                android:textAppearance="?android:textAppearanceSmall" />
+
+            <CheckBox
+                android:id="@+id/checkbox_hide_bottom_controls"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/label_hide_bottom_ui_controls"
+                android:textAppearance="?android:textAppearanceMedium" />
 
         </LinearLayout>
 

--- a/sample/src/main/res/layout/activity_sample.xml
+++ b/sample/src/main/res/layout/activity_sample.xml
@@ -33,7 +33,7 @@
                 android:text="@string/app_name"
                 android:textColor="@color/colorAccent"
                 android:textSize="42sp"
-                android:textStyle="bold" />
+                android:textStyle="bold"/>
 
             <Button
                 android:id="@+id/button_crop"
@@ -43,13 +43,13 @@
                 android:textAllCaps="true"
                 android:textAppearance="?android:textAppearanceMedium"
                 android:textColor="@android:color/white"
-                android:textStyle="bold" />
+                android:textStyle="bold"/>
 
             <View
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_margin="5dp"
-                android:background="@color/colorAccent" />
+                android:background="@color/colorAccent"/>
 
             <RadioGroup
                 android:id="@+id/radio_group_aspect_ratio"
@@ -61,7 +61,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:text="@string/label_aspect_ratio"
-                    android:textAppearance="?android:textAppearanceSmall" />
+                    android:textAppearance="?android:textAppearanceSmall"/>
 
                 <RadioButton
                     android:id="@+id/radio_dynamic"
@@ -69,21 +69,21 @@
                     android:layout_height="wrap_content"
                     android:text="@string/label_dynamic"
                     android:textAppearance="?android:textAppearanceMedium"
-                    tools:checked="true" />
+                    tools:checked="true"/>
 
                 <RadioButton
                     android:id="@+id/radio_origin"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/label_image_source"
-                    android:textAppearance="?android:textAppearanceMedium" />
+                    android:textAppearance="?android:textAppearanceMedium"/>
 
                 <RadioButton
                     android:id="@+id/radio_square"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/label_square"
-                    android:textAppearance="?android:textAppearanceMedium" />
+                    android:textAppearance="?android:textAppearanceMedium"/>
 
                 <LinearLayout
                     android:layout_width="140dp"
@@ -97,13 +97,13 @@
                         android:layout_weight="1"
                         android:gravity="center"
                         android:hint="x"
-                        android:inputType="numberDecimal" />
+                        android:inputType="numberDecimal"/>
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="to"
-                        tools:ignore="HardcodedText" />
+                        tools:ignore="HardcodedText"/>
 
                     <EditText
                         android:id="@+id/edit_text_ratio_y"
@@ -112,7 +112,7 @@
                         android:layout_weight="1"
                         android:gravity="center"
                         android:hint="y"
-                        android:inputType="numberDecimal" />
+                        android:inputType="numberDecimal"/>
 
                 </LinearLayout>
 
@@ -122,21 +122,21 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_margin="5dp"
-                android:background="@color/colorAccent" />
+                android:background="@color/colorAccent"/>
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:text="@string/label_max_cropped_image_size"
-                android:textAppearance="?android:textAppearanceSmall" />
+                android:textAppearance="?android:textAppearanceSmall"/>
 
             <CheckBox
                 android:id="@+id/checkbox_max_size"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/label_resize_image_to_max_size"
-                android:textAppearance="?android:textAppearanceMedium" />
+                android:textAppearance="?android:textAppearanceMedium"/>
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -150,13 +150,13 @@
                     android:layout_weight="1"
                     android:gravity="center"
                     android:hint="@string/label_width"
-                    android:inputType="number" />
+                    android:inputType="number"/>
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="x"
-                    tools:ignore="HardcodedText" />
+                    tools:ignore="HardcodedText"/>
 
                 <EditText
                     android:id="@+id/edit_text_max_height"
@@ -165,7 +165,7 @@
                     android:layout_weight="1"
                     android:gravity="center"
                     android:hint="@string/label_height"
-                    android:inputType="number" />
+                    android:inputType="number"/>
 
             </LinearLayout>
 
@@ -173,7 +173,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_margin="5dp"
-                android:background="@color/colorAccent" />
+                android:background="@color/colorAccent"/>
 
             <RadioGroup
                 android:id="@+id/radio_group_compression_settings"
@@ -185,7 +185,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:text="@string/label_compression_settings"
-                    android:textAppearance="?android:textAppearanceSmall" />
+                    android:textAppearance="?android:textAppearanceSmall"/>
 
                 <RadioButton
                     android:id="@+id/radio_jpeg"
@@ -194,7 +194,7 @@
                     android:text="JPEG"
                     android:textAppearance="?android:textAppearanceMedium"
                     tools:checked="true"
-                    tools:ignore="HardcodedText" />
+                    tools:ignore="HardcodedText"/>
 
                 <RadioButton
                     android:id="@+id/radio_png"
@@ -202,7 +202,7 @@
                     android:layout_height="wrap_content"
                     android:text="PNG"
                     android:textAppearance="?android:textAppearanceMedium"
-                    tools:ignore="HardcodedText" />
+                    tools:ignore="HardcodedText"/>
 
                 <RadioButton
                     android:id="@+id/radio_webp"
@@ -210,7 +210,7 @@
                     android:layout_height="wrap_content"
                     android:text="WEBP"
                     android:textAppearance="?android:textAppearanceMedium"
-                    tools:ignore="HardcodedText" />
+                    tools:ignore="HardcodedText"/>
 
                 <TextView
                     android:id="@+id/text_view_quality"
@@ -218,13 +218,13 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:textAppearance="?android:textAppearanceSmall"
-                    tools:text="Quality: 90" />
+                    tools:text="Quality: 90"/>
 
                 <SeekBar
                     android:id="@+id/seekbar_quality"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    tools:progress="90" />
+                    tools:progress="90"/>
 
             </RadioGroup>
 
@@ -232,19 +232,19 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_margin="5dp"
-                android:background="@color/colorAccent" />
+                android:background="@color/colorAccent"/>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
                 android:text="@string/label_ui"
-                android:textAppearance="?android:textAppearanceSmall" />
+                    android:textAppearance="?android:textAppearanceSmall"/>
 
             <CheckBox
                 android:id="@+id/checkbox_hide_bottom_controls"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                 android:text="@string/label_hide_bottom_ui_controls"
                 android:textAppearance="?android:textAppearanceMedium" />
 

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -9,9 +9,11 @@
     <string name="label_square">Square</string>
     <string name="label_max_cropped_image_size">Max cropped image size</string>
     <string name="label_compression_settings">Compression settings</string>
+    <string name="label_ui">UI</string>
     <string name="label_width">Width</string>
     <string name="label_height">Height</string>
     <string name="label_resize_image_to_max_size">Resize image to max size</string>
+    <string name="label_hide_bottom_ui_controls">Hide bottom UI controls</string>
     <string name="label_select_picture">Select Picture</string>
     <string name="label_cancel">Cancel</string>
     <string name="label_ok">OK</string>

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
@@ -241,7 +241,7 @@ public class UCrop {
 
         public static final String EXTRA_UCROP_LOGO_COLOR = EXTRA_PREFIX + ".UcropLogoColor";
 
-        public static final String EXTRA_SHOW_BOTTOM_CONTROLS = EXTRA_PREFIX + ".ShowBottomControls";
+        public static final String EXTRA_HIDE_BOTTOM_CONTROLS = EXTRA_PREFIX + ".HideBottomControls";
 
 
         private final Bundle mOptionBundle;
@@ -418,10 +418,10 @@ public class UCrop {
         }
 
         /**
-         * @param show - set to true to show the bottom controls
+         * @param hide - set to true to hide the bottom controls (shown by default)
          */
-        public void setShowBottomControls(boolean show) {
-            mOptionBundle.putBoolean(EXTRA_SHOW_BOTTOM_CONTROLS, show);
+        public void setHideBottomControls(boolean hide) {
+            mOptionBundle.putBoolean(EXTRA_HIDE_BOTTOM_CONTROLS, hide);
         }
 
     }

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
@@ -241,6 +241,8 @@ public class UCrop {
 
         public static final String EXTRA_UCROP_LOGO_COLOR = EXTRA_PREFIX + ".UcropLogoColor";
 
+        public static final String EXTRA_SHOW_BOTTOM_CONTROLS = EXTRA_PREFIX + ".ShowBottomControls";
+
 
         private final Bundle mOptionBundle;
 
@@ -413,6 +415,13 @@ public class UCrop {
          */
         public void setLogoColor(@ColorInt int color) {
             mOptionBundle.putInt(EXTRA_UCROP_LOGO_COLOR, color);
+        }
+
+        /**
+         * @param show - set to true to show the bottom controls
+         */
+        public void setShowBottomControls(boolean show) {
+            mOptionBundle.putBoolean(EXTRA_SHOW_BOTTOM_CONTROLS, show);
         }
 
     }

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
@@ -27,7 +27,6 @@ import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.yalantis.ucrop.UCrop.Options;
 import com.yalantis.ucrop.util.BitmapLoadUtils;
 import com.yalantis.ucrop.util.SelectedStateListDrawable;
 import com.yalantis.ucrop.view.CropImageView;
@@ -77,6 +76,7 @@ public class UCropActivity extends AppCompatActivity {
     private int mActiveWidgetColor;
     private int mToolbarTextColor;
     private int mLogoColor;
+
     private boolean mShowBottomControls;
 
     private UCropView mUCropView;
@@ -161,7 +161,7 @@ public class UCropActivity extends AppCompatActivity {
         }
 
         if (intent.getBooleanExtra(UCrop.EXTRA_ASPECT_RATIO_SET, false)) {
-            if (mWrapperStateAspectRatio != null) {
+            if (mShowBottomControls) {
                 mWrapperStateAspectRatio.setVisibility(View.GONE);
             }
 
@@ -239,14 +239,22 @@ public class UCropActivity extends AppCompatActivity {
         mToolbarTitle = intent.getStringExtra(UCrop.Options.EXTRA_UCROP_TITLE_TEXT_TOOLBAR);
         mToolbarTitle = !TextUtils.isEmpty(mToolbarTitle) ? mToolbarTitle : getResources().getString(R.string.ucrop_label_edit_photo);
         mLogoColor = intent.getIntExtra(UCrop.Options.EXTRA_UCROP_LOGO_COLOR, ContextCompat.getColor(this, R.color.ucrop_color_default_logo));
-        mShowBottomControls = intent.getBooleanExtra(Options.EXTRA_SHOW_BOTTOM_CONTROLS, true);
+        mShowBottomControls = !intent.getBooleanExtra(UCrop.Options.EXTRA_HIDE_BOTTOM_CONTROLS, false);
+
+        if (mShowBottomControls) {
+            ViewGroup photoBox = (ViewGroup) findViewById(R.id.ucrop_photobox);
+            View.inflate(this, R.layout.ucrop_controls, photoBox);
+        }
 
         setupAppBar();
         initiateRootViews();
-        setupAspectRatioWidget();
-        setupRotateWidget();
-        setupScaleWidget();
-        setupStatesWrapper();
+
+        if (mShowBottomControls) {
+            setupAspectRatioWidget();
+            setupRotateWidget();
+            setupScaleWidget();
+            setupStatesWrapper();
+        }
     }
 
     /**
@@ -295,10 +303,6 @@ public class UCropActivity extends AppCompatActivity {
             mLayoutAspectRatio = (ViewGroup) findViewById(R.id.layout_aspect_ratio);
             mLayoutRotate = (ViewGroup) findViewById(R.id.layout_rotate_wheel);
             mLayoutScale = (ViewGroup) findViewById(R.id.layout_scale_wheel);
-        } else {
-            findViewById(R.id.wrapper_controls).setVisibility(View.GONE);
-            findViewById(R.id.wrapper_shadow).setVisibility(View.GONE);
-            findViewById(R.id.wrapper_states).setVisibility(View.GONE);
         }
 
         ((ImageView) findViewById(R.id.image_view_logo)).setColorFilter(mLogoColor, PorterDuff.Mode.SRC_ATOP);
@@ -349,10 +353,6 @@ public class UCropActivity extends AppCompatActivity {
      * Use {@link #mActiveWidgetColor} for color filter
      */
     private void setupStatesWrapper() {
-        if (!mShowBottomControls) {
-            return;
-        }
-
         ImageView stateScaleImageView = (ImageView) findViewById(R.id.image_view_state_scale);
         ImageView stateRotateImageView = (ImageView) findViewById(R.id.image_view_state_rotate);
         ImageView stateAspectRatioImageView = (ImageView) findViewById(R.id.image_view_state_aspect_ratio);
@@ -507,10 +507,14 @@ public class UCropActivity extends AppCompatActivity {
     };
 
     private void setInitialState() {
-        if (mWrapperStateAspectRatio != null && mWrapperStateAspectRatio.getVisibility() == View.VISIBLE) {
-            setWidgetState(R.id.state_aspect_ratio);
+        if (mShowBottomControls) {
+            if (mWrapperStateAspectRatio.getVisibility() == View.VISIBLE) {
+                setWidgetState(R.id.state_aspect_ratio);
+            } else {
+                setWidgetState(R.id.state_scale);
+            }
         } else {
-            setWidgetState(R.id.state_scale);
+            setAllowedGestures(2);
         }
     }
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
@@ -27,6 +27,7 @@ import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.yalantis.ucrop.UCrop.Options;
 import com.yalantis.ucrop.util.BitmapLoadUtils;
 import com.yalantis.ucrop.util.SelectedStateListDrawable;
 import com.yalantis.ucrop.view.CropImageView;
@@ -76,6 +77,7 @@ public class UCropActivity extends AppCompatActivity {
     private int mActiveWidgetColor;
     private int mToolbarTextColor;
     private int mLogoColor;
+    private boolean mShowBottomControls;
 
     private UCropView mUCropView;
     private GestureCropImageView mGestureCropImageView;
@@ -159,7 +161,9 @@ public class UCropActivity extends AppCompatActivity {
         }
 
         if (intent.getBooleanExtra(UCrop.EXTRA_ASPECT_RATIO_SET, false)) {
-            mWrapperStateAspectRatio.setVisibility(View.GONE);
+            if (mWrapperStateAspectRatio != null) {
+                mWrapperStateAspectRatio.setVisibility(View.GONE);
+            }
 
             float aspectRatioX = intent.getFloatExtra(UCrop.EXTRA_ASPECT_RATIO_X, 0);
             float aspectRatioY = intent.getFloatExtra(UCrop.EXTRA_ASPECT_RATIO_Y, 0);
@@ -235,6 +239,7 @@ public class UCropActivity extends AppCompatActivity {
         mToolbarTitle = intent.getStringExtra(UCrop.Options.EXTRA_UCROP_TITLE_TEXT_TOOLBAR);
         mToolbarTitle = !TextUtils.isEmpty(mToolbarTitle) ? mToolbarTitle : getResources().getString(R.string.ucrop_label_edit_photo);
         mLogoColor = intent.getIntExtra(UCrop.Options.EXTRA_UCROP_LOGO_COLOR, ContextCompat.getColor(this, R.color.ucrop_color_default_logo));
+        mShowBottomControls = intent.getBooleanExtra(Options.EXTRA_SHOW_BOTTOM_CONTROLS, true);
 
         setupAppBar();
         initiateRootViews();
@@ -279,16 +284,22 @@ public class UCropActivity extends AppCompatActivity {
 
         mGestureCropImageView.setTransformImageListener(mImageListener);
 
-        mWrapperStateAspectRatio = (ViewGroup) findViewById(R.id.state_aspect_ratio);
-        mWrapperStateAspectRatio.setOnClickListener(mStateClickListener);
-        mWrapperStateRotate = (ViewGroup) findViewById(R.id.state_rotate);
-        mWrapperStateRotate.setOnClickListener(mStateClickListener);
-        mWrapperStateScale = (ViewGroup) findViewById(R.id.state_scale);
-        mWrapperStateScale.setOnClickListener(mStateClickListener);
+        if (mShowBottomControls) {
+            mWrapperStateAspectRatio = (ViewGroup) findViewById(R.id.state_aspect_ratio);
+            mWrapperStateAspectRatio.setOnClickListener(mStateClickListener);
+            mWrapperStateRotate = (ViewGroup) findViewById(R.id.state_rotate);
+            mWrapperStateRotate.setOnClickListener(mStateClickListener);
+            mWrapperStateScale = (ViewGroup) findViewById(R.id.state_scale);
+            mWrapperStateScale.setOnClickListener(mStateClickListener);
 
-        mLayoutAspectRatio = (ViewGroup) findViewById(R.id.layout_aspect_ratio);
-        mLayoutRotate = (ViewGroup) findViewById(R.id.layout_rotate_wheel);
-        mLayoutScale = (ViewGroup) findViewById(R.id.layout_scale_wheel);
+            mLayoutAspectRatio = (ViewGroup) findViewById(R.id.layout_aspect_ratio);
+            mLayoutRotate = (ViewGroup) findViewById(R.id.layout_rotate_wheel);
+            mLayoutScale = (ViewGroup) findViewById(R.id.layout_scale_wheel);
+        } else {
+            findViewById(R.id.wrapper_controls).setVisibility(View.GONE);
+            findViewById(R.id.wrapper_shadow).setVisibility(View.GONE);
+            findViewById(R.id.wrapper_states).setVisibility(View.GONE);
+        }
 
         ((ImageView) findViewById(R.id.image_view_logo)).setColorFilter(mLogoColor, PorterDuff.Mode.SRC_ATOP);
     }
@@ -338,6 +349,10 @@ public class UCropActivity extends AppCompatActivity {
      * Use {@link #mActiveWidgetColor} for color filter
      */
     private void setupStatesWrapper() {
+        if (!mShowBottomControls) {
+            return;
+        }
+
         ImageView stateScaleImageView = (ImageView) findViewById(R.id.image_view_state_scale);
         ImageView stateRotateImageView = (ImageView) findViewById(R.id.image_view_state_rotate);
         ImageView stateAspectRatioImageView = (ImageView) findViewById(R.id.image_view_state_aspect_ratio);
@@ -492,6 +507,10 @@ public class UCropActivity extends AppCompatActivity {
     };
 
     private void setInitialState() {
+        if (!mShowBottomControls) {
+            return;
+        }
+
         if (mWrapperStateAspectRatio.getVisibility() == View.VISIBLE) {
             setWidgetState(R.id.state_aspect_ratio);
         } else {
@@ -500,6 +519,10 @@ public class UCropActivity extends AppCompatActivity {
     }
 
     private void setWidgetState(@IdRes int stateViewId) {
+        if (!mShowBottomControls) {
+            return;
+        }
+
         mWrapperStateAspectRatio.setSelected(stateViewId == R.id.state_aspect_ratio);
         mWrapperStateRotate.setSelected(stateViewId == R.id.state_rotate);
         mWrapperStateScale.setSelected(stateViewId == R.id.state_scale);

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
@@ -507,11 +507,7 @@ public class UCropActivity extends AppCompatActivity {
     };
 
     private void setInitialState() {
-        if (!mShowBottomControls) {
-            return;
-        }
-
-        if (mWrapperStateAspectRatio.getVisibility() == View.VISIBLE) {
+        if (mWrapperStateAspectRatio != null && mWrapperStateAspectRatio.getVisibility() == View.VISIBLE) {
             setWidgetState(R.id.state_aspect_ratio);
         } else {
             setWidgetState(R.id.state_scale);
@@ -519,17 +515,15 @@ public class UCropActivity extends AppCompatActivity {
     }
 
     private void setWidgetState(@IdRes int stateViewId) {
-        if (!mShowBottomControls) {
-            return;
+        if (mShowBottomControls) {
+            mWrapperStateAspectRatio.setSelected(stateViewId == R.id.state_aspect_ratio);
+            mWrapperStateRotate.setSelected(stateViewId == R.id.state_rotate);
+            mWrapperStateScale.setSelected(stateViewId == R.id.state_scale);
+
+            mLayoutAspectRatio.setVisibility(stateViewId == R.id.state_aspect_ratio ? View.VISIBLE : View.GONE);
+            mLayoutRotate.setVisibility(stateViewId == R.id.state_rotate ? View.VISIBLE : View.GONE);
+            mLayoutScale.setVisibility(stateViewId == R.id.state_scale ? View.VISIBLE : View.GONE);
         }
-
-        mWrapperStateAspectRatio.setSelected(stateViewId == R.id.state_aspect_ratio);
-        mWrapperStateRotate.setSelected(stateViewId == R.id.state_rotate);
-        mWrapperStateScale.setSelected(stateViewId == R.id.state_scale);
-
-        mLayoutAspectRatio.setVisibility(stateViewId == R.id.state_aspect_ratio ? View.VISIBLE : View.GONE);
-        mLayoutRotate.setVisibility(stateViewId == R.id.state_rotate ? View.VISIBLE : View.GONE);
-        mLayoutScale.setVisibility(stateViewId == R.id.state_scale ? View.VISIBLE : View.GONE);
 
         if (stateViewId == R.id.state_scale) {
             setAllowedGestures(0);

--- a/ucrop/src/main/res/layout/ucrop_activity_photobox.xml
+++ b/ucrop/src/main/res/layout/ucrop_activity_photobox.xml
@@ -20,7 +20,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:text="@string/ucrop_label_edit_photo"
-            android:textColor="@color/ucrop_color_title" />
+            android:textColor="@color/ucrop_color_title"/>
 
     </android.support.v7.widget.Toolbar>
 
@@ -39,13 +39,13 @@
             android:layout_gravity="center"
             app:srcCompat="@drawable/ucrop_vector_ic_crop"
             tools:background="@drawable/ucrop_vector_ic_crop"
-            tools:ignore="MissingPrefix" />
+            tools:ignore="MissingPrefix"/>
 
         <com.yalantis.ucrop.view.UCropView
             android:id="@+id/ucrop"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="invisible" />
+            android:visibility="invisible"/>
 
     </FrameLayout>
 

--- a/ucrop/src/main/res/layout/ucrop_activity_photobox.xml
+++ b/ucrop/src/main/res/layout/ucrop_activity_photobox.xml
@@ -1,4 +1,5 @@
 <RelativeLayout
+    android:id="@+id/ucrop_photobox"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -19,7 +20,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:text="@string/ucrop_label_edit_photo"
-            android:textColor="@color/ucrop_color_title"/>
+            android:textColor="@color/ucrop_color_title" />
 
     </android.support.v7.widget.Toolbar>
 
@@ -38,87 +39,14 @@
             android:layout_gravity="center"
             app:srcCompat="@drawable/ucrop_vector_ic_crop"
             tools:background="@drawable/ucrop_vector_ic_crop"
-            tools:ignore="MissingPrefix"/>
+            tools:ignore="MissingPrefix" />
 
         <com.yalantis.ucrop.view.UCropView
             android:id="@+id/ucrop"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="invisible"/>
+            android:visibility="invisible" />
 
     </FrameLayout>
-
-    <FrameLayout
-        android:id="@+id/wrapper_controls"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/ucrop_height_wrapper_controls"
-        android:layout_above="@+id/wrapper_states"
-        android:background="@color/ucrop_color_widget_background">
-
-        <include
-            android:id="@+id/layout_aspect_ratio"
-            layout="@layout/ucrop_layout_aspect_ratio"/>
-
-        <include
-            android:id="@+id/layout_rotate_wheel"
-            layout="@layout/ucrop_layout_rotate_wheel"/>
-
-        <include
-            android:id="@+id/layout_scale_wheel"
-            layout="@layout/ucrop_layout_scale_wheel"/>
-
-    </FrameLayout>
-
-    <ImageView
-        android:id="@+id/wrapper_shadow"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/ucrop_height_divider_shadow"
-        android:layout_above="@+id/wrapper_states"
-        android:background="@drawable/ucrop_shadow_upside"/>
-
-    <LinearLayout
-        android:id="@+id/wrapper_states"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/ucrop_height_wrapper_states"
-        android:layout_alignParentBottom="true"
-        android:background="@color/ucrop_color_widget_background"
-        android:baselineAligned="false"
-        android:gravity="center"
-        android:orientation="horizontal">
-
-        <FrameLayout
-            android:id="@+id/state_scale"
-            style="@style/ucrop_WrapperIconState">
-
-            <ImageView
-                android:id="@+id/image_view_state_scale"
-                style="@style/ucrop_ImageViewWidgetIcon"
-                android:src="@drawable/ucrop_ic_scale"/>
-
-        </FrameLayout>
-
-        <FrameLayout
-            android:id="@+id/state_aspect_ratio"
-            style="@style/ucrop_WrapperIconState">
-
-            <ImageView
-                android:id="@+id/image_view_state_aspect_ratio"
-                style="@style/ucrop_ImageViewWidgetIcon"
-                android:src="@drawable/ucrop_ic_crop"/>
-
-        </FrameLayout>
-
-        <FrameLayout
-            android:id="@+id/state_rotate"
-            style="@style/ucrop_WrapperIconState">
-
-            <ImageView
-                android:id="@+id/image_view_state_rotate"
-                style="@style/ucrop_ImageViewWidgetIcon"
-                android:src="@drawable/ucrop_ic_rotate"/>
-
-        </FrameLayout>
-
-    </LinearLayout>
 
 </RelativeLayout>

--- a/ucrop/src/main/res/layout/ucrop_activity_photobox.xml
+++ b/ucrop/src/main/res/layout/ucrop_activity_photobox.xml
@@ -70,6 +70,7 @@
     </FrameLayout>
 
     <ImageView
+        android:id="@+id/wrapper_shadow"
         android:layout_width="match_parent"
         android:layout_height="@dimen/ucrop_height_divider_shadow"
         android:layout_above="@+id/wrapper_states"

--- a/ucrop/src/main/res/layout/ucrop_controls.xml
+++ b/ucrop/src/main/res/layout/ucrop_controls.xml
@@ -12,15 +12,15 @@
 
         <include
             android:id="@+id/layout_aspect_ratio"
-            layout="@layout/ucrop_layout_aspect_ratio" />
+            layout="@layout/ucrop_layout_aspect_ratio"/>
 
         <include
             android:id="@+id/layout_rotate_wheel"
-            layout="@layout/ucrop_layout_rotate_wheel" />
+            layout="@layout/ucrop_layout_rotate_wheel"/>
 
         <include
             android:id="@+id/layout_scale_wheel"
-            layout="@layout/ucrop_layout_scale_wheel" />
+            layout="@layout/ucrop_layout_scale_wheel"/>
 
     </FrameLayout>
 
@@ -28,7 +28,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/ucrop_height_divider_shadow"
         android:layout_above="@+id/wrapper_states"
-        android:background="@drawable/ucrop_shadow_upside" />
+        android:background="@drawable/ucrop_shadow_upside"/>
 
     <LinearLayout
         android:id="@+id/wrapper_states"
@@ -47,7 +47,7 @@
             <ImageView
                 android:id="@+id/image_view_state_scale"
                 style="@style/ucrop_ImageViewWidgetIcon"
-                android:src="@drawable/ucrop_ic_scale" />
+                android:src="@drawable/ucrop_ic_scale"/>
 
         </FrameLayout>
 
@@ -58,7 +58,7 @@
             <ImageView
                 android:id="@+id/image_view_state_aspect_ratio"
                 style="@style/ucrop_ImageViewWidgetIcon"
-                android:src="@drawable/ucrop_ic_crop" />
+                android:src="@drawable/ucrop_ic_crop"/>
 
         </FrameLayout>
 
@@ -69,7 +69,7 @@
             <ImageView
                 android:id="@+id/image_view_state_rotate"
                 style="@style/ucrop_ImageViewWidgetIcon"
-                android:src="@drawable/ucrop_ic_rotate" />
+                android:src="@drawable/ucrop_ic_rotate"/>
 
         </FrameLayout>
 

--- a/ucrop/src/main/res/layout/ucrop_controls.xml
+++ b/ucrop/src/main/res/layout/ucrop_controls.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    tools:showIn="@layout/ucrop_activity_photobox">
+
+    <FrameLayout
+        android:id="@+id/wrapper_controls"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/ucrop_height_wrapper_controls"
+        android:layout_above="@+id/wrapper_states"
+        android:background="@color/ucrop_color_widget_background">
+
+        <include
+            android:id="@+id/layout_aspect_ratio"
+            layout="@layout/ucrop_layout_aspect_ratio" />
+
+        <include
+            android:id="@+id/layout_rotate_wheel"
+            layout="@layout/ucrop_layout_rotate_wheel" />
+
+        <include
+            android:id="@+id/layout_scale_wheel"
+            layout="@layout/ucrop_layout_scale_wheel" />
+
+    </FrameLayout>
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/ucrop_height_divider_shadow"
+        android:layout_above="@+id/wrapper_states"
+        android:background="@drawable/ucrop_shadow_upside" />
+
+    <LinearLayout
+        android:id="@+id/wrapper_states"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/ucrop_height_wrapper_states"
+        android:layout_alignParentBottom="true"
+        android:background="@color/ucrop_color_widget_background"
+        android:baselineAligned="false"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <FrameLayout
+            android:id="@+id/state_scale"
+            style="@style/ucrop_WrapperIconState">
+
+            <ImageView
+                android:id="@+id/image_view_state_scale"
+                style="@style/ucrop_ImageViewWidgetIcon"
+                android:src="@drawable/ucrop_ic_scale" />
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/state_aspect_ratio"
+            style="@style/ucrop_WrapperIconState">
+
+            <ImageView
+                android:id="@+id/image_view_state_aspect_ratio"
+                style="@style/ucrop_ImageViewWidgetIcon"
+                android:src="@drawable/ucrop_ic_crop" />
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/state_rotate"
+            style="@style/ucrop_WrapperIconState">
+
+            <ImageView
+                android:id="@+id/image_view_state_rotate"
+                style="@style/ucrop_ImageViewWidgetIcon"
+                android:src="@drawable/ucrop_ic_rotate" />
+
+        </FrameLayout>
+
+    </LinearLayout>
+</merge>


### PR DESCRIPTION
Added an option to completely hide (as in: not inflate) the controls at the bottom of the cropping UI. This way the user can only crop the image using gestures on the grid. 
Screenshot: 
![device-2016-04-03-185650](https://cloud.githubusercontent.com/assets/9164783/14256264/9b120ac8-fa98-11e5-9978-b9c5526e7810.png)

The default is still the same as before, i.e. showing bottom controls.

I've also extended the sample app to include this option. 
Sample app: 
![device-2016-04-03-185733](https://cloud.githubusercontent.com/assets/9164783/14256299/bcb870fe-fa98-11e5-95dc-5e6147dfc3e1.png)
