### PR TITLE
Fixed rounding of image sizes by using Math.round instead of casting to int

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
@@ -107,8 +107,8 @@ public class CropImageView extends TransformImageView {
                 float resizeScale = Math.min(scaleX, scaleY);
 
                 Bitmap resizedBitmap = Bitmap.createScaledBitmap(viewBitmap,
-                        (int) (viewBitmap.getWidth() * resizeScale),
-                        (int) (viewBitmap.getHeight() * resizeScale), false);
+                        Math.round(viewBitmap.getWidth() * resizeScale),
+                        Math.round(viewBitmap.getHeight() * resizeScale), false);
                 if (viewBitmap != resizedBitmap) {
                     viewBitmap.recycle();
                 }
@@ -130,10 +130,10 @@ public class CropImageView extends TransformImageView {
             viewBitmap = rotatedBitmap;
         }
 
-        int top = (int) ((mCropRect.top - currentImageRect.top) / currentScale);
-        int left = (int) ((mCropRect.left - currentImageRect.left) / currentScale);
-        int width = (int) (mCropRect.width() / currentScale);
-        int height = (int) (mCropRect.height() / currentScale);
+        int top = Math.round((mCropRect.top - currentImageRect.top) / currentScale);
+        int left = Math.round((mCropRect.left - currentImageRect.left) / currentScale);
+        int width = Math.round(mCropRect.width() / currentScale);
+        int height = Math.round(mCropRect.height() / currentScale);
 
         return Bitmap.createBitmap(viewBitmap, left, top, width, height);
     }


### PR DESCRIPTION
This PR fixes #73.

I've basically just replaced int-casts with Math.round as a possible solution.

Is there a specific reason you are casting floats to integers directly, that I've missed or am not aware of? If so, do let me know. 

I have tested this solution and it seems to work, however further testing would not hurt :)
