### PR TITLE
rm useless and harmful bitmap recycling

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
@@ -81,7 +81,6 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
 
         try {
             crop(resizeScale);
-            mViewBitmap.recycle();
             mViewBitmap = null;
         } catch (Throwable throwable) {
             return throwable;

--- a/ucrop/src/main/java/com/yalantis/ucrop/util/BitmapLoadUtils.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/util/BitmapLoadUtils.java
@@ -36,7 +36,6 @@ public class BitmapLoadUtils {
         try {
             Bitmap converted = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), transformMatrix, true);
             if (bitmap != converted) {
-                bitmap.recycle();
                 bitmap = converted;
             }
         } catch (OutOfMemoryError error) {


### PR DESCRIPTION
Hello, and thanks for this amazing lib!

Though the calls to `Bitmap.recycle()` are redundant on api 11+, since bitmaps are stored on the Java heap now.

And they are actually harmful - I'm reusing bitmaps heavily in my application, and once I crop one of them, they become useless (every method stars throwing exceptions after `.recycle()`) and I have to track that.

I suggest removing these method calls altogether