### PR TITLE
Downgrade to SDK 23 for a known bug

### DIFF
--- a/ucrop/build.gradle
+++ b/ucrop/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply from: '../mavenpush.gradle'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 23
     buildToolsVersion '24.0.0'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 24
+        targetSdkVersion 23
         versionCode 20
         versionName "2.1.1"
 
@@ -36,6 +36,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:24.0.1'
+    compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.squareup.okhttp3:okhttp:3.3.1'
 }

--- a/ucrop/build.gradle
+++ b/ucrop/build.gradle
@@ -36,6 +36,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:24.0.0'
+    compile 'com.android.support:appcompat-v7:24.0.1'
     compile 'com.squareup.okhttp3:okhttp:3.3.1'
 }


### PR DESCRIPTION
Found this [known bug, recognized by a Google employee](http://stackoverflow.com/a/37337203), so I think for now it's better to downgrade to SDK 23.