### PR TITLE
fixed setTargetAspectRatio has run before onLayout in OverlayView.

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/view/OverlayView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/OverlayView.java
@@ -187,10 +187,16 @@ public class OverlayView extends View {
      *
      * @param targetAspectRatio - aspect ratio for image crop (e.g. 1.77(7) for 16:9)
      */
-    public void setTargetAspectRatio(float targetAspectRatio) {
-        mTargetAspectRatio = targetAspectRatio;
-        setupCropBounds();
-        postInvalidate();
+    public void setTargetAspectRatio(final float targetAspectRatio) {
+        post(new Runnable() {
+            @Override
+            public void run() {
+                mTargetAspectRatio = targetAspectRatio;
+                setupCropBounds();
+                postInvalidate();
+            }
+        });
+
     }
 
     /**


### PR DESCRIPTION
i have use ucorp in my company's app,it's wonderful .
But some users said that sometimes they do not see the crop box when using the croppin on some phone .
I reproduce the problem , and  found when setTargetAspectRatio method run，sometimes mThisWidth and mThisHeight are both 0. 