### PR TITLE
Fixed null file sent back (Issue #142)

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/util/FileUtils.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/util/FileUtils.java
@@ -520,6 +520,14 @@ public class FileUtils {
     }
 
     public static void copyFile(@NonNull String pathFrom, @NonNull String pathTo) throws IOException {
+        /*
+        In the event that the paths are the same, trying to copy one file to the other
+        will cause both files to become null. simply skipping this step if the paths
+        are identical solves that problem
+         */
+        if(pathFrom.equalsIgnoreCase(pathTo)){
+            return;
+        }
         FileChannel outputChannel = null;
         FileChannel inputChannel = null;
         try {


### PR DESCRIPTION
As per issue 142 (https://github.com/Yalantis/uCrop/issues/142), it mentions the issue of files being sent back as null if they make no changes (No cropping). The solution was simply just to check the paths and confirm if they are identical. In the event that the paths are the same, trying to copy one file to the other will cause both files to become null. simply skipping this step if the paths are identical solves that problem. This pull request should fix that issue entirely