### PR TITLE
Fix #121 Bitmap too large~ 

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/view/TransformImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/TransformImageView.java
@@ -11,6 +11,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.View;
 import android.widget.ImageView;
 
 import com.yalantis.ucrop.callback.BitmapLoadCallback;
@@ -18,6 +19,8 @@ import com.yalantis.ucrop.model.ExifInfo;
 import com.yalantis.ucrop.util.BitmapLoadUtils;
 import com.yalantis.ucrop.util.FastBitmapDrawable;
 import com.yalantis.ucrop.util.RectUtils;
+
+import javax.microedition.khronos.opengles.GL10;
 
 /**
  * Created by Oleksii Shliama (https://github.com/shliama).
@@ -114,6 +117,11 @@ public class TransformImageView extends ImageView {
 
     @Override
     public void setImageBitmap(final Bitmap bitmap) {
+        // Check the bitmap extend and switch to software layer if necessary
+        final int maxSize = GL10.GL_MAX_TEXTURE_SIZE;
+        if (bitmap.getWidth() > maxSize || bitmap.getHeight() > maxSize) {
+            setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+        }
         setImageDrawable(new FastBitmapDrawable(bitmap));
     }
 


### PR DESCRIPTION
fix 'Bitmap too large to be uploaded into a texture' by checking bitmap extend and switching to software layer type when size limit reached