### PR TITLE
Made cropCIMG static

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
@@ -169,7 +169,7 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
     }
 
     @SuppressWarnings("JniMissingFunction")
-    native public boolean
+    native public static boolean
     cropCImg(String inputPath, String outputPath,
              int left, int top, int width, int height,
              float angle, float resizeScale,


### PR DESCRIPTION
I'm customizing uCrop try to add some image preprocessing support such as applying filters, tune brightness, etc.

I need build my own BitmapCropTask to do these jobs, but I can't invoke `cropCIMG` in my class, and `cropCIMG` seems no need as a instance method, so I think if it become to a static method should be better.
