### PR TITLE
Prevent rotation of the scale wheel if minimum or maximum scale reached

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
@@ -460,8 +460,9 @@ public class UCropActivity extends AppCompatActivity {
         ((HorizontalProgressWheelView) findViewById(R.id.rotate_scroll_wheel))
                 .setScrollingListener(new HorizontalProgressWheelView.ScrollingListener() {
                     @Override
-                    public void onScroll(float delta, float totalDistance) {
+                    public boolean onScroll(float delta, float totalDistance) {
                         mGestureCropImageView.postRotate(delta / ROTATE_WIDGET_SENSITIVITY_COEFFICIENT);
+                        return true;
                     }
 
                     @Override
@@ -497,12 +498,12 @@ public class UCropActivity extends AppCompatActivity {
         ((HorizontalProgressWheelView) findViewById(R.id.scale_scroll_wheel))
                 .setScrollingListener(new HorizontalProgressWheelView.ScrollingListener() {
                     @Override
-                    public void onScroll(float delta, float totalDistance) {
+                    public boolean onScroll(float delta, float totalDistance) {
                         if (delta > 0) {
-                            mGestureCropImageView.zoomInImage(mGestureCropImageView.getCurrentScale()
+                            return mGestureCropImageView.zoomInImage(mGestureCropImageView.getCurrentScale()
                                     + delta * ((mGestureCropImageView.getMaxScale() - mGestureCropImageView.getMinScale()) / SCALE_WIDGET_SENSITIVITY_COEFFICIENT));
                         } else {
-                            mGestureCropImageView.zoomOutImage(mGestureCropImageView.getCurrentScale()
+                            return mGestureCropImageView.zoomOutImage(mGestureCropImageView.getCurrentScale()
                                     + delta * ((mGestureCropImageView.getMaxScale() - mGestureCropImageView.getMinScale()) / SCALE_WIDGET_SENSITIVITY_COEFFICIENT));
                         }
                     }

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
@@ -197,8 +197,10 @@ public class CropImageView extends TransformImageView {
     /**
      * This method scales image down for given value related to image center.
      */
-    public void zoomOutImage(float deltaScale) {
+    public boolean zoomOutImage(float deltaScale) {
+        if (deltaScale < getMinScale()) return false;
         zoomOutImage(deltaScale, mCropRect.centerX(), mCropRect.centerY());
+        return true;
     }
 
     /**
@@ -213,8 +215,10 @@ public class CropImageView extends TransformImageView {
     /**
      * This method scales image up for given value related to image center.
      */
-    public void zoomInImage(float deltaScale) {
+    public boolean zoomInImage(float deltaScale) {
+        if (deltaScale > getMaxScale()) return false;
         zoomInImage(deltaScale, mCropRect.centerX(), mCropRect.centerY());
+        return true;
     }
 
     /**

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/widget/HorizontalProgressWheelView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/widget/HorizontalProgressWheelView.java
@@ -118,12 +118,15 @@ public class HorizontalProgressWheelView extends View {
     }
 
     private void onScrollEvent(MotionEvent event, float distance) {
+        mLastTouchedPosition = event.getX();
+
+        if (mScrollingListener != null) {
+            boolean result = mScrollingListener.onScroll(-distance, mTotalScrollDistance);
+            if (!result) return;
+        }
+
         mTotalScrollDistance -= distance;
         postInvalidate();
-        mLastTouchedPosition = event.getX();
-        if (mScrollingListener != null) {
-            mScrollingListener.onScroll(-distance, mTotalScrollDistance);
-        }
     }
 
     private void init() {
@@ -143,7 +146,7 @@ public class HorizontalProgressWheelView extends View {
 
         void onScrollStart();
 
-        void onScroll(float delta, float totalDistance);
+        boolean onScroll(float delta, float totalDistance);
 
         void onScrollEnd();
     }


### PR DESCRIPTION
Now if you reach minimum or maximum scale wheel widget continues to rotate.

After this change it will stop rotation.