### PR TITLE
Add ability to attach a Bundle to serve as tag for I/O.

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
@@ -35,6 +35,8 @@ public class UCrop {
 
     private static final String EXTRA_PREFIX = BuildConfig.APPLICATION_ID;
 
+    public static final String EXTRA_IO_TAG = EXTRA_PREFIX + ".Tag";
+
     public static final String EXTRA_INPUT_URI = EXTRA_PREFIX + ".InputUri";
     public static final String EXTRA_OUTPUT_URI = EXTRA_PREFIX + ".OutputUri";
     public static final String EXTRA_OUTPUT_CROP_ASPECT_RATIO = EXTRA_PREFIX + ".CropAspectRatio";
@@ -105,6 +107,12 @@ public class UCrop {
 
     public UCrop withOptions(@NonNull Options options) {
         mCropOptionsBundle.putAll(options.getOptionBundle());
+        return this;
+    }
+
+
+    public UCrop withTag(@NonNull Bundle tag) {
+        mCropOptionsBundle.putBundle(EXTRA_IO_TAG, tag);
         return this;
     }
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
@@ -110,7 +110,11 @@ public class UCrop {
         return this;
     }
 
-
+    /**
+     * Attach a tag to {@link UCropActivity} so that it's received back in onActivityResult().
+     *
+     * @param tag Tag to attach
+     */
     public UCrop withTag(@NonNull Bundle tag) {
         mCropOptionsBundle.putBundle(EXTRA_IO_TAG, tag);
         return this;

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
@@ -92,6 +92,8 @@ public class UCropActivity extends AppCompatActivity {
     private boolean mShowBottomControls;
     private boolean mShowLoader = true;
 
+    private Bundle tag;
+
     private UCropView mUCropView;
     private GestureCropImageView mGestureCropImageView;
     private OverlayView mOverlayView;
@@ -112,6 +114,7 @@ public class UCropActivity extends AppCompatActivity {
 
         final Intent intent = getIntent();
 
+        setupTag(intent);
         setupViews(intent);
         setImageData(intent);
         setInitialState();
@@ -171,6 +174,14 @@ public class UCropActivity extends AppCompatActivity {
         if (mGestureCropImageView != null) {
             mGestureCropImageView.cancelAllAnimations();
         }
+    }
+
+    /**
+     * This method extracts an optional {@link Bundle tag} that should be sent back along with
+     * the result.
+     */
+    private void setupTag(@NonNull Intent intent) {
+        tag = intent.getBundleExtra(UCrop.EXTRA_IO_TAG);
     }
 
     /**
@@ -629,6 +640,7 @@ public class UCropActivity extends AppCompatActivity {
     protected void setResultUri(Uri uri, float resultAspectRatio, int imageWidth, int imageHeight) {
         setResult(RESULT_OK, new Intent()
                 .putExtra(UCrop.EXTRA_OUTPUT_URI, uri)
+                .putExtra(UCrop.EXTRA_IO_TAG, tag)
                 .putExtra(UCrop.EXTRA_OUTPUT_CROP_ASPECT_RATIO, resultAspectRatio)
                 .putExtra(UCrop.EXTRA_OUTPUT_IMAGE_WIDTH, imageWidth)
                 .putExtra(UCrop.EXTRA_OUTPUT_IMAGE_HEIGHT, imageHeight)


### PR DESCRIPTION
Source activity would launch UCrop with such a tag (a Bundle) and receive it back, as-is, in onActivityResult() method.