### PR TITLE
When a square image is rotated by 90 (180, 270) degrees, it is not croped.

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
@@ -167,7 +167,8 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
                 || Math.abs(mCropRect.left - mCurrentImageRect.left) > pixelError
                 || Math.abs(mCropRect.top - mCurrentImageRect.top) > pixelError
                 || Math.abs(mCropRect.bottom - mCurrentImageRect.bottom) > pixelError
-                || Math.abs(mCropRect.right - mCurrentImageRect.right) > pixelError;
+                || Math.abs(mCropRect.right - mCurrentImageRect.right) > pixelError
+                || mCurrentAngle != 0;
     }
 
     @SuppressWarnings("JniMissingFunction")


### PR DESCRIPTION
@Cool04ek 
Thank you this very nice library.

When a square image is rotated by 90 (180, 270) degrees, it is not croped.
So, I added the current angle to shouldCrop method.