### PR TITLE
Fix: Return true from 'onOptionsItemSelected' when item was consumed

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
@@ -159,8 +159,10 @@ public class UCropActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.menu_crop) {
             cropAndSaveImage();
+            return true;
         } else if (item.getItemId() == android.R.id.home) {
             onBackPressed();
+            return true;
         }
         return super.onOptionsItemSelected(item);
     }


### PR DESCRIPTION
As I wrote in #256 my app crashes when `super.onOptionsItemSelected(item)` is called even if the item was consumed already. Hence I propose to add the two return statements in this pull request.
Cheers