### PR TITLE
HotFix for #271

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/view/UCropView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/UCropView.java
@@ -14,7 +14,7 @@ import com.yalantis.ucrop.callback.OverlayViewChangeListener;
 
 public class UCropView extends FrameLayout {
 
-    private final GestureCropImageView mGestureCropImageView;
+    private GestureCropImageView mGestureCropImageView;
     private final OverlayView mViewOverlay;
 
     public UCropView(Context context, AttributeSet attrs) {
@@ -34,6 +34,10 @@ public class UCropView extends FrameLayout {
         a.recycle();
 
 
+        setListenersToViews();
+    }
+
+    private void setListenersToViews() {
         mGestureCropImageView.setCropBoundsChangeListener(new CropBoundsChangeListener() {
             @Override
             public void onCropAspectRatioChanged(float cropRatio) {
@@ -63,4 +67,15 @@ public class UCropView extends FrameLayout {
         return mViewOverlay;
     }
 
+    /**
+     * Method for reset state for UCropImageView such as rotation, scale, translation.
+     * Be careful: this method recreate UCropImageView instance and reattach it to layout.
+     */
+    public void resetCropImageView() {
+        removeView(mGestureCropImageView);
+        mGestureCropImageView = new GestureCropImageView(getContext());
+        setListenersToViews();
+        mGestureCropImageView.setCropRect(getOverlayView().getCropViewRect());
+        addView(mGestureCropImageView, 0);
+    }
 }


### PR DESCRIPTION
For reset all states for `UCropImageView` could be used method `resetCropImageView()`