### PR TITLE
Sometimes it's useful to allow destination uri to be null.

### DIFF
--- a/sample/src/main/java/com/yalantis/ucrop/sample/SampleActivity.java
+++ b/sample/src/main/java/com/yalantis/ucrop/sample/SampleActivity.java
@@ -9,7 +9,9 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
+import android.support.v7.app.AlertDialog;
 import android.text.Editable;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
@@ -24,8 +26,10 @@ import com.yalantis.ucrop.UCrop;
 import com.yalantis.ucrop.UCropActivity;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Random;
+import java.util.TreeSet;
 
 /**
  * Created by Oleksii Shliama (https://github.com/shliama).
@@ -45,6 +49,7 @@ public class SampleActivity extends BaseActivity {
     private TextView mTextViewQuality;
     private CheckBox mCheckBoxHideBottomControls;
     private CheckBox mCheckBoxFreeStyleCrop;
+    private CheckBox mCheckBoxCropBoundaries;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -120,6 +125,7 @@ public class SampleActivity extends BaseActivity {
         mTextViewQuality = ((TextView) findViewById(R.id.text_view_quality));
         mCheckBoxHideBottomControls = ((CheckBox) findViewById(R.id.checkbox_hide_bottom_controls));
         mCheckBoxFreeStyleCrop = ((CheckBox) findViewById(R.id.checkbox_freestyle_crop));
+        mCheckBoxCropBoundaries = ((CheckBox) findViewById(R.id.checkbox_crop_boundaries));
 
         mRadioGroupAspectRatio.check(R.id.radio_dynamic);
         mEditTextRatioX.addTextChangedListener(mAspectRatioTextWatcher);
@@ -194,8 +200,8 @@ public class SampleActivity extends BaseActivity {
                 destinationFileName += ".jpg";
                 break;
         }
-
-        UCrop uCrop = UCrop.of(uri, Uri.fromFile(new File(getCacheDir(), destinationFileName)));
+        boolean boundaries = mCheckBoxCropBoundaries.isChecked();
+        UCrop uCrop = UCrop.of(uri, boundaries ? null : Uri.fromFile(new File(getCacheDir(), destinationFileName)));
 
         uCrop = basisConfig(uCrop);
         uCrop = advancedConfig(uCrop);
@@ -326,7 +332,20 @@ public class SampleActivity extends BaseActivity {
         if (resultUri != null) {
             ResultActivity.startWithUri(SampleActivity.this, resultUri);
         } else {
-            Toast.makeText(SampleActivity.this, R.string.toast_cannot_retrieve_cropped_image, Toast.LENGTH_SHORT).show();
+            ArrayList<String> output = new ArrayList<>();
+            Bundle extras = result.getExtras();
+            if (extras != null) {
+                for (String key : new TreeSet<>(extras.keySet())) {
+                    output.add(String.format("%s: %s", key, extras.get(key)));
+                }
+            }
+            if (output.size() > 0)
+                new AlertDialog.Builder(SampleActivity.this)
+                        .setMessage(TextUtils.join("\n", output))
+                        .setPositiveButton(android.R.string.ok, null)
+                        .create().show();
+            else
+                Toast.makeText(SampleActivity.this, R.string.toast_cannot_retrieve_cropped_image, Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/sample/src/main/res/layout/activity_sample.xml
+++ b/sample/src/main/res/layout/activity_sample.xml
@@ -257,6 +257,12 @@
                 android:text="@string/label_hide_bottom_ui_controls"
                 android:textAppearance="?android:textAppearanceMedium"/>
 
+            <CheckBox
+                android:id="@+id/checkbox_crop_boundaries"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/label_crop_boundaries"
+                android:textAppearance="?android:textAppearanceMedium"/>
         </LinearLayout>
 
     </FrameLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="label_height">Height</string>
     <string name="label_resize_image_to_max_size">Resize image to max size</string>
     <string name="label_hide_bottom_ui_controls">Hide bottom UI controls</string>
+    <string name="label_crop_boundaries">Crop boundaries only</string>
     <string name="label_freestyle_crop">Freestyle crop</string>
     <string name="label_select_picture">Select Picture</string>
     <string name="label_cancel">Cancel</string>

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
@@ -50,6 +50,10 @@ public class UCrop {
     public static final String EXTRA_MAX_SIZE_X = EXTRA_PREFIX + ".MaxSizeX";
     public static final String EXTRA_MAX_SIZE_Y = EXTRA_PREFIX + ".MaxSizeY";
 
+    public static final String EXTRA_OUTPUT_ORIGIN_WIDTH = EXTRA_PREFIX + ".OriginWidth";
+    public static final String EXTRA_OUTPUT_ORIGIN_HEIGHT = EXTRA_PREFIX + ".OriginHeight";
+    public static final String EXTRA_OUTPUT_ORIGIN_URI = EXTRA_PREFIX + ".OriginUri";
+
     private Intent mCropIntent;
     private Bundle mCropOptionsBundle;
 
@@ -59,11 +63,13 @@ public class UCrop {
      * @param source      Uri for image to crop
      * @param destination Uri for saving the cropped image
      */
-    public static UCrop of(@NonNull Uri source, @NonNull Uri destination) {
+    public static UCrop of(@NonNull Uri source, @Nullable Uri destination) {
         return new UCrop(source, destination);
     }
-
-    private UCrop(@NonNull Uri source, @NonNull Uri destination) {
+    public static UCrop of(@NonNull Uri source) {
+        return new UCrop(source, null);
+    }
+    private UCrop(@NonNull Uri source, @Nullable Uri destination) {
         mCropIntent = new Intent();
         mCropOptionsBundle = new Bundle();
         mCropOptionsBundle.putParcelable(EXTRA_INPUT_URI, source);

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
@@ -14,6 +14,7 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.IdRes;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -181,7 +182,7 @@ public class UCropActivity extends AppCompatActivity {
         Uri outputUri = intent.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI);
         processOptions(intent);
 
-        if (inputUri != null && outputUri != null) {
+        if (inputUri != null) {
             try {
                 mGestureCropImageView.setImageUri(inputUri, outputUri);
             } catch (Exception e) {
@@ -612,8 +613,8 @@ public class UCropActivity extends AppCompatActivity {
         mGestureCropImageView.cropAndSaveImage(mCompressFormat, mCompressQuality, new BitmapCropCallback() {
 
             @Override
-            public void onBitmapCropped(@NonNull Uri resultUri, int offsetX, int offsetY, int imageWidth, int imageHeight) {
-                setResultUri(resultUri, mGestureCropImageView.getTargetAspectRatio(), offsetX, offsetY, imageWidth, imageHeight);
+            public void onBitmapCropped(@Nullable Uri resultUri, int offsetX, int offsetY, int imageWidth, int imageHeight, int originWidth, int originHeight, Uri originUri) {
+                setResultUri(resultUri, mGestureCropImageView.getTargetAspectRatio(), offsetX, offsetY, imageWidth, imageHeight, originWidth, originHeight, originUri);
                 finish();
             }
 
@@ -625,7 +626,7 @@ public class UCropActivity extends AppCompatActivity {
         });
     }
 
-    protected void setResultUri(Uri uri, float resultAspectRatio, int offsetX, int offsetY, int imageWidth, int imageHeight) {
+    protected void setResultUri(Uri uri, float resultAspectRatio, int offsetX, int offsetY, int imageWidth, int imageHeight, int originWidth, int originHeight, Uri originUri) {
         setResult(RESULT_OK, new Intent()
                 .putExtra(UCrop.EXTRA_OUTPUT_URI, uri)
                 .putExtra(UCrop.EXTRA_OUTPUT_CROP_ASPECT_RATIO, resultAspectRatio)
@@ -633,6 +634,9 @@ public class UCropActivity extends AppCompatActivity {
                 .putExtra(UCrop.EXTRA_OUTPUT_IMAGE_HEIGHT, imageHeight)
                 .putExtra(UCrop.EXTRA_OUTPUT_OFFSET_X, offsetX)
                 .putExtra(UCrop.EXTRA_OUTPUT_OFFSET_Y, offsetY)
+                .putExtra(UCrop.EXTRA_OUTPUT_ORIGIN_WIDTH, originWidth)
+                .putExtra(UCrop.EXTRA_OUTPUT_ORIGIN_HEIGHT, originHeight)
+                .putExtra(UCrop.EXTRA_OUTPUT_ORIGIN_URI, originUri)
         );
     }
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/callback/BitmapCropCallback.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/callback/BitmapCropCallback.java
@@ -2,10 +2,11 @@ package com.yalantis.ucrop.callback;
 
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 public interface BitmapCropCallback {
 
-    void onBitmapCropped(@NonNull Uri resultUri, int offsetX, int offsetY, int imageWidth, int imageHeight);
+    void onBitmapCropped(@Nullable Uri resultUri, int offsetX, int offsetY, int imageWidth, int imageHeight, int originWidth, int originHeight, Uri originUri);
 
     void onCropFailure(@NonNull Throwable t);
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapLoadTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapLoadTask.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.UUID;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -201,7 +202,8 @@ public class BitmapLoadTask extends AsyncTask<Void, Void, BitmapLoadTask.BitmapW
         Log.d(TAG, "copyFile");
 
         if (outputUri == null) {
-            throw new NullPointerException("Output Uri is null - cannot copy image");
+//            throw new NullPointerException("Output Uri is null - cannot copy image");
+            outputUri = Uri.fromFile(new File(mContext.getCacheDir(), UUID.randomUUID().toString()));
         }
 
         InputStream inputStream = null;
@@ -224,7 +226,7 @@ public class BitmapLoadTask extends AsyncTask<Void, Void, BitmapLoadTask.BitmapW
 
             // swap uris, because input image was copied to the output destination
             // (cropped image will override it later)
-            mInputUri = mOutputUri;
+            mInputUri = outputUri;
         }
     }
 
@@ -232,7 +234,8 @@ public class BitmapLoadTask extends AsyncTask<Void, Void, BitmapLoadTask.BitmapW
         Log.d(TAG, "downloadFile");
 
         if (outputUri == null) {
-            throw new NullPointerException("Output Uri is null - cannot download image");
+//            throw new NullPointerException("Output Uri is null - cannot download image");
+            outputUri = Uri.fromFile(new File(mContext.getCacheDir(), UUID.randomUUID().toString()));
         }
 
         OkHttpClient client = new OkHttpClient();
@@ -264,7 +267,7 @@ public class BitmapLoadTask extends AsyncTask<Void, Void, BitmapLoadTask.BitmapW
 
             // swap uris, because input image was downloaded to the output destination
             // (cropped image will override it later)
-            mInputUri = mOutputUri;
+            mInputUri = outputUri;
         }
     }
 


### PR DESCRIPTION
Sometimes it's useful to get a cropping range instead of actually cropping a image. So allow destination uri to be null, do not actually cropped when the destination uri is null, add more crop rect info into result intent. 
#188 