### PR TITLE
Translation for Korean added.

### DIFF
--- a/ucrop/src/main/res/values-ko/strings.xml
+++ b/ucrop/src/main/res/values-ko/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="ucrop_label_edit_photo">사진 편집</string>
+    <string name="ucrop_label_original">원본</string>
+    <string name="ucrop_menu_crop">확인</string>
+</resources>


### PR DESCRIPTION
Hi, I add translations for Korean.
FYI, "확인" is not a direct translation for "ucrop_menu_crop"(Crop)", but it means confirm. 
(In my culture, a word for 'crop' is not common for this kind of action.)
It works in most cases I guess.

Thanks.