### PR TITLE
compatibled for using in fragment

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropFragment.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropFragment.java
@@ -95,12 +95,13 @@ public class UCropFragment extends Fragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        try {
+        if (getParentFragment() instanceof UCropFragmentCallback)
+            callback = (UCropFragmentCallback) getParentFragment();
+        else if (context instanceof UCropFragmentCallback)
             callback = (UCropFragmentCallback) context;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(context.toString()
+        else
+            throw new IllegalArgumentException(context.toString()
                     + " must implement UCropFragmentCallback");
-        }
     }
 
     public void setCallback(UCropFragmentCallback callback) {


### PR DESCRIPTION
After this change we can use `UCropFragment` in another fragment as a child!