### PR TITLE
Functionality to enable/disable gestures in GestureCropImageView

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/view/GestureCropImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/GestureCropImageView.java
@@ -21,7 +21,7 @@ public class GestureCropImageView extends CropImageView {
 
     private float mMidPntX, mMidPntY;
 
-    private boolean mIsRotateEnabled = true, mIsScaleEnabled = true;
+    private boolean mIsRotateEnabled = true, mIsScaleEnabled = true, mIsGestureEnabled = true;
     private int mDoubleTapScaleSteps = 5;
 
     public GestureCropImageView(Context context) {
@@ -52,6 +52,14 @@ public class GestureCropImageView extends CropImageView {
         return mIsRotateEnabled;
     }
 
+    public void setGestureEnabled(boolean gestureEnabled) {
+        mIsGestureEnabled = gestureEnabled;
+    }
+
+    public boolean isGestureEnabled() {
+        return mIsGestureEnabled;
+    }
+
     public void setDoubleTapScaleSteps(int doubleTapScaleSteps) {
         mDoubleTapScaleSteps = doubleTapScaleSteps;
     }
@@ -77,7 +85,9 @@ public class GestureCropImageView extends CropImageView {
             mMidPntY = (event.getY(0) + event.getY(1)) / 2;
         }
 
-        mGestureDetector.onTouchEvent(event);
+        if (mIsGestureEnabled) {
+            mGestureDetector.onTouchEvent(event);
+        }
 
         if (mIsScaleEnabled) {
             mScaleDetector.onTouchEvent(event);


### PR DESCRIPTION
Exposing options to enable/disable gestures in GestureCropImageView when required.

Referencing issue: [https://github.com/Yalantis/uCrop/issues/609](https://github.com/Yalantis/uCrop/issues/609)