### PR TITLE
fix crash 'Canvas: trying to draw too large bitmap.'

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapLoadTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapLoadTask.java
@@ -95,6 +95,7 @@ public class BitmapLoadTask extends AsyncTask<Void, Void, BitmapLoadTask.BitmapW
         Bitmap decodeSampledBitmap = null;
 
         boolean decodeAttemptSuccess = false;
+        final int MAX_BITMAP_SIZE = 100 * 1024 * 1024; // 100 MB
         while (!decodeAttemptSuccess) {
             try {
                 InputStream stream = mContext.getContentResolver().openInputStream(mInputUri);
@@ -105,6 +106,11 @@ public class BitmapLoadTask extends AsyncTask<Void, Void, BitmapLoadTask.BitmapW
                     }
                 } finally {
                     BitmapLoadUtils.close(stream);
+                }
+                int bitmapSize = decodeSampledBitmap != null ? decodeSampledBitmap.getByteCount() : 0;
+                if (bitmapSize > MAX_BITMAP_SIZE) { // AVOID CRASH 'Canvas: trying to draw too large bitmap.'
+                    options.inSampleSize *= 2;
+                    continue;
                 }
                 decodeAttemptSuccess = true;
             } catch (OutOfMemoryError error) {


### PR DESCRIPTION
A solution to [https://github.com/Yalantis/uCrop/issues/648](#648)