### PR TITLE
Fix for problems with input and output File Uri with "content" schema and Android 10 SAF new requirements.

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
-        android:requestLegacyExternalStorage="true"
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <provider

--- a/sample/src/main/res/drawable/bg_button.xml
+++ b/sample/src/main/res/drawable/bg_button.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/colorAccent" />
+        </shape>
+    </item>
+    <item android:state_enabled="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/colorButtonDisabled" />
+        </shape>
+    </item>
+</selector>

--- a/sample/src/main/res/drawable/bg_text_border.xml
+++ b/sample/src/main/res/drawable/bg_text_border.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@android:color/white" />
+    <stroke android:width="1dp" android:color="@color/colorAccent" />
+    <corners android:radius="10dp" />
+</shape>

--- a/sample/src/main/res/layout/activity_result.xml
+++ b/sample/src/main/res/layout/activity_result.xml
@@ -15,6 +15,16 @@
         app:title="@string/format_crop_result_d_d"
         app:titleTextColor="@android:color/white"/>
 
+    <TextView
+        android:id="@+id/text_view_content_warning"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:textColor="@android:color/holo_red_dark"
+        android:textAppearance="?android:textAppearanceLarge"
+        android:text="@string/text_view_content_warning_text"
+        android:visibility="gone"/>
+
     <com.yalantis.ucrop.view.UCropView
         android:id="@+id/ucrop"
         android:layout_width="match_parent"

--- a/sample/src/main/res/layout/dialog_file_destination.xml
+++ b/sample/src/main/res/layout/dialog_file_destination.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingLeft="20dp"
+    android:paddingRight="20dp">
+
+    <RadioGroup
+        android:id="@+id/radio_group_directory"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:checkedButton="@+id/radio_external_storage_dcim">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/choose_the_destination_directory"
+            android:textAppearance="?android:textAppearanceSmall" />
+
+        <RadioButton
+            android:id="@+id/radio_external_storage_dcim"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="@string/radio_external_storage_dcim_text"/>
+
+        <RadioButton
+            android:id="@+id/radio_external_storage_pictures"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/radio_external_storage_pictures_text"/>
+
+        <RadioButton
+            android:id="@+id/radio_app_external_storage_dcim"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/radio_app_external_storage_dcim_text"/>
+
+        <RadioButton
+            android:id="@+id/radio_app_external_storage_pictures"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/radio_app_external_storage_pictures_text"/>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_margin="5dp"
+            android:background="@color/colorAccent" />
+
+    </RadioGroup>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/file_name"
+        android:textAppearance="?android:textAppearanceSmall" />
+
+    <EditText
+        android:id="@+id/edit_text_file_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/edit_text_file_name_hint"
+        android:autofillHints="SampleFile"/>
+
+</LinearLayout>

--- a/sample/src/main/res/layout/include_settings.xml
+++ b/sample/src/main/res/layout/include_settings.xml
@@ -61,6 +61,85 @@
                 android:layout_margin="5dp"
                 android:background="@color/colorAccent" />
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <RadioGroup
+                    android:id="@+id/radio_group_choose_destination"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <RadioButton
+                        android:id="@+id/radio_tmp_destination"
+                        android:layout_width="0dp"
+                        android:layout_weight="0.5"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="?android:textAppearanceMedium"
+                        android:text="@string/radio_tmp_destination_text"
+                        tools:checked="true"/>
+
+                    <RadioButton
+                        android:id="@+id/radio_choose_destination"
+                        android:layout_width="0dp"
+                        android:layout_weight="0.5"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="?android:textAppearanceMedium"
+                            android:text="@string/radio_choose_destination"/>
+
+                </RadioGroup>
+
+                <!-- Only visible for Android API versions between 19 and 28 -->
+                <CheckBox
+                    android:id="@+id/checkbox_use_document_provider"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/checkbox_use_document_provider_text"
+                    android:checked="true"
+                    android:enabled="false"
+                    android:visibility="gone"/>
+
+                <CheckBox
+                    android:id="@+id/checkbox_use_file_provider"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/checkbox_use_file_provider_text"
+                    android:checked="true"
+                    android:enabled="false"
+                    android:visibility="gone"/>
+
+                <Button
+                    android:id="@+id/button_file_destination"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/button_file_destination"
+                    android:textAllCaps="true"
+                    android:enabled="false"
+                    style="@style/DestinationButton"
+                    android:textAppearance="?android:textAppearanceMedium"
+                    android:textColor="@android:color/white"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/file_destination_label"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:visibility="gone"
+                    android:text=""
+                    style="@style/DestinationText" />
+
+            </LinearLayout>
+
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_margin="5dp"
+                android:background="@color/colorAccent" />
+
             <RadioGroup
                 android:id="@+id/radio_group_aspect_ratio"
                 android:layout_width="match_parent"

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <color name="colorPrimary">#FF6E40</color>
     <color name="colorPrimaryDark">#CC5833</color>
     <color name="colorAccent">#FF6E40</color>
+    <color name="colorButtonDisabled">#80FF6E40</color>
 
     <color name="your_color_res">#03A9F4</color>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -46,4 +46,25 @@
     <string name="file_provider_authorities">com.yalantis.ucrop.provider</string>
     <string name="channel_name">ucrop_chanel</string>
     <string name="channel_description">ucrop result image</string>
+    <string name="button_file_destination">Chose File Destination</string>
+    <string name="no_file_chooser_error">No application found on device to open view</string>
+
+    <!-- Choose File Dialog -->
+    <string name="choose_the_destination_directory">Choose the Destination Directory</string>
+    <string name="radio_external_storage_dcim_text">Shared Storage DCIM</string>
+    <string name="radio_external_storage_pictures_text">Shared Storage Pictures</string>
+    <string name="radio_app_external_storage_dcim_text">App External Storage DCIM</string>
+    <string name="radio_app_external_storage_pictures_text">App External Storage Pictures</string>
+    <string name="file_name">File name</string>
+    <string name="edit_text_file_name_hint">@string/file_name</string>
+
+    <string name="radio_tmp_destination_text">Tmp File destination</string>
+    <string name="radio_choose_destination">Choose destination</string>
+    <string name="checkbox_use_document_provider_text">Use document provider for creating or choosing the destination file</string>
+    <string name="checkbox_use_file_provider_text">Use a file provider for creating the file destination URI</string>
+
+    <string name="text_view_content_warning_text">
+        Warning: On Android versions lower then Lollipop, if the output file URI has a \"content\"
+        schema, it is not possible to preserve the Exif info!
+    </string>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
     <string name="file_provider_authorities">com.yalantis.ucrop.provider</string>
     <string name="channel_name">ucrop_chanel</string>
     <string name="channel_description">ucrop result image</string>
-    <string name="button_file_destination">Chose File Destination</string>
+    <string name="button_file_destination">Choose File Destination</string>
     <string name="no_file_chooser_error">No application found on device to open view</string>
 
     <!-- Choose File Dialog -->

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="DestinationButton" parent="Widget.AppCompat.Button.Colored">
+        <item name="background">@drawable/bg_text_border</item>
+    </style>
+
+    <style name="DestinationText" parent="Widget.AppCompat.TextView">
+        <item name="android:background">@drawable/bg_text_border</item>
+        <item name="android:textAppearance">?android:textAppearanceMedium</item>
+        <item name="android:layout_marginLeft">2dp</item>
+        <item name="android:layout_marginRight">2dp</item>
+    </style>
+
+</resources>

--- a/ucrop/build.gradle
+++ b/ucrop/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply from: '../mavenpush.gradle'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 25
         versionName "2.2.5-non-native"
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/callback/BitmapLoadCallback.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/callback/BitmapLoadCallback.java
@@ -1,6 +1,7 @@
 package com.yalantis.ucrop.callback;
 
 import android.graphics.Bitmap;
+import android.net.Uri;
 
 import com.yalantis.ucrop.model.ExifInfo;
 
@@ -9,7 +10,7 @@ import androidx.annotation.Nullable;
 
 public interface BitmapLoadCallback {
 
-    void onBitmapLoaded(@NonNull Bitmap bitmap, @NonNull ExifInfo exifInfo, @NonNull String imageInputPath, @Nullable String imageOutputPath);
+    void onBitmapLoaded(@NonNull Bitmap bitmap, @NonNull ExifInfo exifInfo, @NonNull Uri imageInputUri, @Nullable Uri imageOutputUri);
 
     void onFailure(@NonNull Exception bitmapWorkerException);
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/model/CropParameters.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/model/CropParameters.java
@@ -1,6 +1,7 @@
 package com.yalantis.ucrop.model;
 
 import android.graphics.Bitmap;
+import android.net.Uri;
 
 /**
  * Created by Oleksii Shliama [https://github.com/shliama] on 6/21/16.
@@ -13,6 +14,8 @@ public class CropParameters {
     private int mCompressQuality;
     private String mImageInputPath, mImageOutputPath;
     private ExifInfo mExifInfo;
+
+    private Uri mContentImageInputUri, mContentImageOutputUri;
 
 
     public CropParameters(int maxResultImageSizeX, int maxResultImageSizeY,
@@ -55,4 +58,19 @@ public class CropParameters {
         return mExifInfo;
     }
 
+    public Uri getContentImageInputUri() {
+        return mContentImageInputUri;
+    }
+
+    public void setContentImageInputUri(Uri mContentImageInputUri) {
+        this.mContentImageInputUri = mContentImageInputUri;
+    }
+
+    public Uri getContentImageOutputUri() {
+        return mContentImageOutputUri;
+    }
+
+    public void setContentImageOutputUri(Uri mContentImageOutputUri) {
+        this.mContentImageOutputUri = mContentImageOutputUri;
+    }
 }

--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
@@ -106,6 +106,11 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
     }
 
     private boolean crop() throws IOException {
+        Context context = mContext.get();
+        if (context == null) {
+            return false;
+        }
+
         // Downsize if needed
         if (mMaxResultImageSizeX > 0 && mMaxResultImageSizeY > 0) {
             float cropWidth = mCropRect.width() / mCurrentScale;
@@ -155,16 +160,16 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
             if (mCompressFormat.equals(Bitmap.CompressFormat.JPEG)) {
                 if (mImageInputUri != null && "content".equals(mImageInputUri.getScheme()) && "content".equals(mImageOutputUri.getScheme())) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                        ImageHeaderParser.copyExif(mContext.get(), mCroppedImageWidth, mCroppedImageHeight, mImageInputUri, mImageOutputUri);
+                        ImageHeaderParser.copyExif(context, mCroppedImageWidth, mCroppedImageHeight, mImageInputUri, mImageOutputUri);
                     } else {
                         Log.e(TAG, "It is not possible to write exif info into file represented by \"content\" Uri if Android < LOLLIPOP");
                     }
                 } else if (mImageInputUri != null && "content".equals(mImageInputUri.getScheme())) {
-                    ImageHeaderParser.copyExif(mContext.get(), mCroppedImageWidth, mCroppedImageHeight, mImageInputUri, mImageOutputPath);
+                    ImageHeaderParser.copyExif(context, mCroppedImageWidth, mCroppedImageHeight, mImageInputUri, mImageOutputPath);
                 } else if (mImageOutputUri != null && "content".equals(mImageOutputUri.getScheme())) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                         ExifInterface originalExif = new ExifInterface(mImageInputPath);
-                        ImageHeaderParser.copyExif(mContext.get(), originalExif, mCroppedImageWidth, mCroppedImageHeight, mImageOutputUri);
+                        ImageHeaderParser.copyExif(context, originalExif, mCroppedImageWidth, mCroppedImageHeight, mImageOutputUri);
                     } else {
                         Log.e(TAG, "It is not possible to write exif info into file represented by \"content\" Uri if Android < LOLLIPOP");
                     }
@@ -175,7 +180,7 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
             }
             return true;
         } else {
-            FileUtils.copyFile(mContext.get() ,mImageInputUri, mImageOutputUri);
+            FileUtils.copyFile(context ,mImageInputUri, mImageOutputUri);
             return false;
         }
     }

--- a/ucrop/src/main/java/com/yalantis/ucrop/util/FileUtils.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/util/FileUtils.java
@@ -32,6 +32,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.util.Locale;
 
@@ -215,6 +217,9 @@ public class FileUtils {
      * In the event that the paths are the same, trying to copy one file to the other
      * will cause both files to become null.
      * Simply skipping this step if the paths are identical.
+     *
+     * @param pathFrom Represents the source file
+     * @param pathTo Represents the destination file
      */
     public static void copyFile(@NonNull String pathFrom, @NonNull String pathTo) throws IOException {
         if (pathFrom.equalsIgnoreCase(pathTo)) {
@@ -227,10 +232,41 @@ public class FileUtils {
             inputChannel = new FileInputStream(new File(pathFrom)).getChannel();
             outputChannel = new FileOutputStream(new File(pathTo)).getChannel();
             inputChannel.transferTo(0, inputChannel.size(), outputChannel);
-            inputChannel.close();
         } finally {
             if (inputChannel != null) inputChannel.close();
             if (outputChannel != null) outputChannel.close();
+        }
+    }
+
+    /**
+     * Copies one file into the other with the given Uris.
+     * In the event that the Uris are the same, trying to copy one file to the other
+     * will cause both files to become null.
+     * Simply skipping this step if the paths are identical.
+     *
+     * @param context The context from which to require the {@link android.content.ContentResolver}
+     * @param uriFrom Represents the source file
+     * @param uriTo Represents the destination file
+     */
+    public static void copyFile(@NonNull Context context, @NonNull Uri uriFrom, @NonNull Uri uriTo) throws IOException {
+        if (uriFrom.equals(uriTo)) {
+            return;
+        }
+
+        InputStream isFrom = null;
+        OutputStream osTo = null;
+        try {
+            isFrom = context.getContentResolver().openInputStream(uriFrom);
+            osTo = context.getContentResolver().openOutputStream(uriTo);
+
+            if (isFrom instanceof FileInputStream && osTo instanceof FileOutputStream) {
+                FileChannel inputChannel = ((FileInputStream)isFrom).getChannel();
+                FileChannel outputChannel = ((FileOutputStream)osTo).getChannel();
+                inputChannel.transferTo(0, inputChannel.size(), outputChannel);
+            }
+        } finally {
+            if (isFrom != null) isFrom.close();
+            if (osTo != null) osTo.close();
         }
     }
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/util/FileUtils.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/util/FileUtils.java
@@ -263,6 +263,9 @@ public class FileUtils {
                 FileChannel inputChannel = ((FileInputStream)isFrom).getChannel();
                 FileChannel outputChannel = ((FileOutputStream)osTo).getChannel();
                 inputChannel.transferTo(0, inputChannel.size(), outputChannel);
+            } else {
+                throw new IllegalArgumentException("The input or output URI don't represent a file. " +
+                                                   "uCrop requires then to represent files in order to work properly.");
             }
         } finally {
             if (isFrom != null) isFrom.close();

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
@@ -84,6 +84,9 @@ public class CropImageView extends TransformImageView {
                 compressFormat, compressQuality,
                 getImageInputPath(), getImageOutputPath(), getExifInfo());
 
+        cropParameters.setContentImageInputUri(getImageInputUri());
+        cropParameters.setContentImageOutputUri(getImageOutputUri());
+
         new BitmapCropTask(getContext(), getViewBitmap(), imageState, cropParameters, cropCallback)
                 .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/TransformImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/TransformImageView.java
@@ -53,6 +53,7 @@ public class TransformImageView extends AppCompatImageView {
     private int mMaxBitmapSize = 0;
 
     private String mImageInputPath, mImageOutputPath;
+    private Uri mImageInputUri, mImageOutputUri;
     private ExifInfo mExifInfo;
 
     /**
@@ -126,6 +127,14 @@ public class TransformImageView extends AppCompatImageView {
         return mImageOutputPath;
     }
 
+    public Uri getImageInputUri() {
+        return mImageInputUri;
+    }
+
+    public Uri getImageOutputUri() {
+        return mImageOutputUri;
+    }
+
     public ExifInfo getExifInfo() {
         return mExifInfo;
     }
@@ -143,9 +152,11 @@ public class TransformImageView extends AppCompatImageView {
                 new BitmapLoadCallback() {
 
                     @Override
-                    public void onBitmapLoaded(@NonNull Bitmap bitmap, @NonNull ExifInfo exifInfo, @NonNull String imageInputPath, @Nullable String imageOutputPath) {
-                        mImageInputPath = imageInputPath;
-                        mImageOutputPath = imageOutputPath;
+                    public void onBitmapLoaded(@NonNull Bitmap bitmap, @NonNull ExifInfo exifInfo, @NonNull Uri imageInputUri, @Nullable Uri imageOutputUri) {
+                        mImageInputUri = imageInputUri;
+                        mImageOutputUri = imageOutputUri;
+                        mImageInputPath = imageInputUri.getPath();
+                        mImageOutputPath = imageOutputUri != null ? imageOutputUri.getPath() : null;
                         mExifInfo = exifInfo;
 
                         mBitmapDecoded = true;


### PR DESCRIPTION
### List of changes:

- Fix for problems with input and output File Uri with "content" schema.
- Fix for using uCrop with SAF (Storage Access Framework) on Android 10 and newer.
- Sample app changed for context file testing. Added a "choose file destination" button and some other associated controls.

### Important note:

This is a fix for the non-native version since I don't even know if it is possible to deal with those things in native code.

### Related and fixed issues:

This fix problems reported on issues #668, #718 and #666.

### Explanation of the solution:

Basically I've adapted many of the existing code to rely more on the Uri whenever it is possible rather than using only the file paths. 

The most significant changes were made on `BitmapCropTask` and `ImageHeaderParser` classes but that were made some minor changes on `BitmapLoadTask` too.

I had to change the way the exif info was been copied from the input file to the output file and because those were some delicate changes I tried to do this in a more conservative way allowing the behavior to change more for the newer Android versions were it was needed more and conserving the behavior where it wasn't necessary to change (e.g. when the output Uri hasn't the "content" schema). 

### How to test the changes:

In order to more easily be able to test those things I made some changes to the sample application by inserting in it some widgets to allow for easy testing of different types of output uri.

![Seleção_123](https://user-images.githubusercontent.com/20728836/104829578-f8861a00-5853-11eb-914f-e01559ae0821.png)

A destination Uri path can be easily selected by using the "Choose destination" controls:

![Seleção_124](https://user-images.githubusercontent.com/20728836/104829633-66cadc80-5854-11eb-89ad-a8f441d70d9b.png)

A "Destination File" dialog was provided for Devices with Android versions that don't have the possibility to use a Document Provider file picker for choosing the destination file path:

![Seleção_125](https://user-images.githubusercontent.com/20728836/104829708-0be5b500-5855-11eb-8e0e-64bb770712d3.png)

To test Uri with "file" or "content" is pretty straightforward:

![Seleção_126](https://user-images.githubusercontent.com/20728836/104829758-94645580-5855-11eb-9d8b-34a20fb7a81f.png)

![Seleção_127](https://user-images.githubusercontent.com/20728836/104829772-c2499a00-5855-11eb-9e31-8333350f421a.png)

I've made my tests varying content and file schema booth for input Uri and output Uri on those Android api: 16, 19, 22, 28, 29 and 30.

### Limitations of the solution:

For Android API lower than Lollipop (21) with a output Uri image with schema "content" it is not possible to preserve the exif info due to `ExifInterface` limitations explained more deeply on this [StackOverflow question](https://stackoverflow.com/questions/65516993/copy-exif-info-from-one-uri-to-the-other-with-the-new-android-scoped-storage). The file is successfully croped but without any exif info.

### Pull request late fixes:

- Typo on "Choose File Destination" button from Sample app
- NullPointerException protection on weak reference of context get on crop method.
- Refactorings on BitmapCropTask for improving readability, protections against null pointer exceptions and minor performance improvements
- IllegalArgumentException in the copyFile method to inform that an unsupported URI was used.
- Merge branch 'master-non-native' to bring commits from fix/non_native_ssl_handshake_exception branch