### PR TITLE
Support circle crop as an aspect ratio option

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
@@ -39,6 +39,7 @@ public class UCrop {
     public static final String EXTRA_INPUT_URI = EXTRA_PREFIX + ".InputUri";
     public static final String EXTRA_OUTPUT_URI = EXTRA_PREFIX + ".OutputUri";
     public static final String EXTRA_OUTPUT_CROP_ASPECT_RATIO = EXTRA_PREFIX + ".CropAspectRatio";
+    public static final String EXTRA_OUTPUT_CIRCLE_CROP = EXTRA_PREFIX + ".CircleCrop";
     public static final String EXTRA_OUTPUT_IMAGE_WIDTH = EXTRA_PREFIX + ".ImageWidth";
     public static final String EXTRA_OUTPUT_IMAGE_HEIGHT = EXTRA_PREFIX + ".ImageHeight";
     public static final String EXTRA_OUTPUT_OFFSET_X = EXTRA_PREFIX + ".OffsetX";
@@ -218,6 +219,16 @@ public class UCrop {
      */
     public static float getOutputCropAspectRatio(@NonNull Intent intent) {
         return intent.getFloatExtra(EXTRA_OUTPUT_CROP_ASPECT_RATIO, 0f);
+    }
+
+    /**
+     * Retrieve if image is circle cropped from the result Intent
+     *
+     * @param intent crop result intent
+     * @return circle crop flag
+     */
+    public static boolean getOutputCircleCrop(@NonNull Intent intent) {
+        return intent.getBooleanExtra(EXTRA_OUTPUT_CIRCLE_CROP, false);
     }
 
     /**

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
@@ -101,9 +101,9 @@ public class UCropActivity extends AppCompatActivity {
     private boolean mShowBottomControls;
     private boolean mShowLoader = true;
 
-    private UCropView mUCropView;
-    private GestureCropImageView mGestureCropImageView;
-    private OverlayView mOverlayView;
+    protected UCropView mUCropView;
+    protected GestureCropImageView mGestureCropImageView;
+    protected OverlayView mOverlayView;
     private ViewGroup mWrapperStateAspectRatio, mWrapperStateRotate, mWrapperStateScale;
     private ViewGroup mLayoutAspectRatio, mLayoutRotate, mLayoutScale;
     private List<ViewGroup> mCropAspectRatioViews = new ArrayList<>();
@@ -269,6 +269,7 @@ public class UCropActivity extends AppCompatActivity {
         } else if (aspectRatioList != null && aspectRationSelectedByDefault < aspectRatioList.size()) {
             mGestureCropImageView.setTargetAspectRatio(aspectRatioList.get(aspectRationSelectedByDefault).getAspectRatioX() /
                     aspectRatioList.get(aspectRationSelectedByDefault).getAspectRatioY());
+            setCircleCrop(aspectRatioList.get(aspectRationSelectedByDefault).isCircle());
         } else {
             mGestureCropImageView.setTargetAspectRatio(CropImageView.SOURCE_IMAGE_ASPECT_RATIO);
         }
@@ -281,6 +282,10 @@ public class UCropActivity extends AppCompatActivity {
             mGestureCropImageView.setMaxResultImageSizeX(maxSizeX);
             mGestureCropImageView.setMaxResultImageSizeY(maxSizeY);
         }
+    }
+
+    protected void setCircleCrop(boolean circleCrop) {
+        mGestureCropImageView.setCircleCrop(circleCrop);
     }
 
     private void setupViews(@NonNull Intent intent) {
@@ -470,9 +475,10 @@ public class UCropActivity extends AppCompatActivity {
             cropAspectRatioView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    mGestureCropImageView.setTargetAspectRatio(
-                            ((AspectRatioTextView) ((ViewGroup) v).getChildAt(0)).getAspectRatio(v.isSelected()));
+                    AspectRatioTextView ratioTextView = ((AspectRatioTextView) ((ViewGroup) v).getChildAt(0));
+                    mGestureCropImageView.setTargetAspectRatio(ratioTextView.getAspectRatio(v.isSelected()));
                     mGestureCropImageView.setImageToWrapCropBounds();
+                    setCircleCrop(ratioTextView.isCircle());
                     if (!v.isSelected()) {
                         for (ViewGroup cropAspectRatioView : mCropAspectRatioViews) {
                             cropAspectRatioView.setSelected(cropAspectRatioView == v);
@@ -669,7 +675,7 @@ public class UCropActivity extends AppCompatActivity {
 
             @Override
             public void onBitmapCropped(@NonNull Uri resultUri, int offsetX, int offsetY, int imageWidth, int imageHeight) {
-                setResultUri(resultUri, mGestureCropImageView.getTargetAspectRatio(), offsetX, offsetY, imageWidth, imageHeight);
+                setResultUri(resultUri, mGestureCropImageView.getTargetAspectRatio(), mGestureCropImageView.isCircleCrop(), offsetX, offsetY, imageWidth, imageHeight);
                 finish();
             }
 
@@ -681,10 +687,11 @@ public class UCropActivity extends AppCompatActivity {
         });
     }
 
-    protected void setResultUri(Uri uri, float resultAspectRatio, int offsetX, int offsetY, int imageWidth, int imageHeight) {
+    protected void setResultUri(Uri uri, float resultAspectRatio, boolean circleCrop, int offsetX, int offsetY, int imageWidth, int imageHeight) {
         setResult(RESULT_OK, new Intent()
                 .putExtra(UCrop.EXTRA_OUTPUT_URI, uri)
                 .putExtra(UCrop.EXTRA_OUTPUT_CROP_ASPECT_RATIO, resultAspectRatio)
+                .putExtra(UCrop.EXTRA_OUTPUT_CIRCLE_CROP, circleCrop)
                 .putExtra(UCrop.EXTRA_OUTPUT_IMAGE_WIDTH, imageWidth)
                 .putExtra(UCrop.EXTRA_OUTPUT_IMAGE_HEIGHT, imageHeight)
                 .putExtra(UCrop.EXTRA_OUTPUT_OFFSET_X, offsetX)

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropFragment.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropFragment.java
@@ -81,9 +81,9 @@ public class UCropFragment extends Fragment {
 
     private Transition mControlsTransition;
 
-    private UCropView mUCropView;
-    private GestureCropImageView mGestureCropImageView;
-    private OverlayView mOverlayView;
+    protected UCropView mUCropView;
+    protected GestureCropImageView mGestureCropImageView;
+    protected OverlayView mOverlayView;
     private ViewGroup mWrapperStateAspectRatio, mWrapperStateRotate, mWrapperStateScale;
     private ViewGroup mLayoutAspectRatio, mLayoutRotate, mLayoutScale;
     private List<ViewGroup> mCropAspectRatioViews = new ArrayList<>();
@@ -250,6 +250,7 @@ public class UCropFragment extends Fragment {
         } else if (aspectRatioList != null && aspectRationSelectedByDefault < aspectRatioList.size()) {
             mGestureCropImageView.setTargetAspectRatio(aspectRatioList.get(aspectRationSelectedByDefault).getAspectRatioX() /
                     aspectRatioList.get(aspectRationSelectedByDefault).getAspectRatioY());
+            setCircleCrop(aspectRatioList.get(aspectRationSelectedByDefault).isCircle());
         } else {
             mGestureCropImageView.setTargetAspectRatio(CropImageView.SOURCE_IMAGE_ASPECT_RATIO);
         }
@@ -262,6 +263,10 @@ public class UCropFragment extends Fragment {
             mGestureCropImageView.setMaxResultImageSizeX(maxSizeX);
             mGestureCropImageView.setMaxResultImageSizeY(maxSizeY);
         }
+    }
+
+    protected void setCircleCrop(boolean circleCrop) {
+        mGestureCropImageView.setCircleCrop(circleCrop);
     }
 
     private void initiateRootViews(View view) {
@@ -353,9 +358,10 @@ public class UCropFragment extends Fragment {
             cropAspectRatioView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    mGestureCropImageView.setTargetAspectRatio(
-                            ((AspectRatioTextView) ((ViewGroup) v).getChildAt(0)).getAspectRatio(v.isSelected()));
+                    AspectRatioTextView ratioTextView = ((AspectRatioTextView) ((ViewGroup) v).getChildAt(0));
+                    mGestureCropImageView.setTargetAspectRatio(ratioTextView.getAspectRatio(v.isSelected()));
                     mGestureCropImageView.setImageToWrapCropBounds();
+                    setCircleCrop(ratioTextView.isCircle());
                     if (!v.isSelected()) {
                         for (ViewGroup cropAspectRatioView : mCropAspectRatioViews) {
                             cropAspectRatioView.setSelected(cropAspectRatioView == v);
@@ -550,7 +556,7 @@ public class UCropFragment extends Fragment {
 
             @Override
             public void onBitmapCropped(@NonNull Uri resultUri, int offsetX, int offsetY, int imageWidth, int imageHeight) {
-                callback.onCropFinish(getResult(resultUri, mGestureCropImageView.getTargetAspectRatio(), offsetX, offsetY, imageWidth, imageHeight));
+                callback.onCropFinish(getResult(resultUri, mGestureCropImageView.getTargetAspectRatio(), mGestureCropImageView.isCircleCrop(), offsetX, offsetY, imageWidth, imageHeight));
                 callback.loadingProgress(false);
             }
 
@@ -561,10 +567,11 @@ public class UCropFragment extends Fragment {
         });
     }
 
-    protected UCropResult getResult(Uri uri, float resultAspectRatio, int offsetX, int offsetY, int imageWidth, int imageHeight) {
+    protected UCropResult getResult(Uri uri, float resultAspectRatio, boolean circleCrop, int offsetX, int offsetY, int imageWidth, int imageHeight) {
         return new UCropResult(RESULT_OK, new Intent()
                 .putExtra(UCrop.EXTRA_OUTPUT_URI, uri)
                 .putExtra(UCrop.EXTRA_OUTPUT_CROP_ASPECT_RATIO, resultAspectRatio)
+                .putExtra(UCrop.EXTRA_OUTPUT_CIRCLE_CROP, circleCrop)
                 .putExtra(UCrop.EXTRA_OUTPUT_IMAGE_WIDTH, imageWidth)
                 .putExtra(UCrop.EXTRA_OUTPUT_IMAGE_HEIGHT, imageHeight)
                 .putExtra(UCrop.EXTRA_OUTPUT_OFFSET_X, offsetX)

--- a/ucrop/src/main/java/com/yalantis/ucrop/model/AspectRatio.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/model/AspectRatio.java
@@ -14,17 +14,24 @@ public class AspectRatio implements Parcelable {
     private final String mAspectRatioTitle;
     private final float mAspectRatioX;
     private final float mAspectRatioY;
+    private final boolean mCircle;
 
     public AspectRatio(@Nullable String aspectRatioTitle, float aspectRatioX, float aspectRatioY) {
+        this(aspectRatioTitle, aspectRatioX, aspectRatioY, false);
+    }
+
+    public AspectRatio(@Nullable String aspectRatioTitle, float aspectRatioX, float aspectRatioY, boolean circle) {
         mAspectRatioTitle = aspectRatioTitle;
         mAspectRatioX = aspectRatioX;
         mAspectRatioY = aspectRatioY;
+        mCircle = circle;
     }
 
     protected AspectRatio(Parcel in) {
         mAspectRatioTitle = in.readString();
         mAspectRatioX = in.readFloat();
         mAspectRatioY = in.readFloat();
+        mCircle = in.readInt() != 0;
     }
 
     @Override
@@ -32,6 +39,7 @@ public class AspectRatio implements Parcelable {
         dest.writeString(mAspectRatioTitle);
         dest.writeFloat(mAspectRatioX);
         dest.writeFloat(mAspectRatioY);
+        dest.writeInt(mCircle ? 1 : 0);
     }
 
     @Override
@@ -64,4 +72,7 @@ public class AspectRatio implements Parcelable {
         return mAspectRatioY;
     }
 
+    public boolean isCircle() {
+        return mCircle;
+    }
 }

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
@@ -44,6 +44,7 @@ public class CropImageView extends TransformImageView {
     private final Matrix mTempMatrix = new Matrix();
 
     private float mTargetAspectRatio;
+    private boolean mCircleCrop;
     private float mMaxScaleMultiplier = DEFAULT_MAX_SCALE_MULTIPLIER;
 
     private CropBoundsChangeListener mCropBoundsChangeListener;
@@ -110,6 +111,13 @@ public class CropImageView extends TransformImageView {
     }
 
     /**
+     * @return - whether circle crop is enabled or not
+     */
+    public boolean isCircleCrop() {
+        return mCircleCrop;
+    }
+
+    /**
      * Updates current crop rectangle with given. Also recalculates image properties and position
      * to fit new crop rectangle.
      *
@@ -146,6 +154,10 @@ public class CropImageView extends TransformImageView {
         if (mCropBoundsChangeListener != null) {
             mCropBoundsChangeListener.onCropAspectRatioChanged(mTargetAspectRatio);
         }
+    }
+
+    public void setCircleCrop(boolean circleCrop) {
+        mCircleCrop = circleCrop;
     }
 
     @Nullable

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/widget/AspectRatioTextView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/widget/AspectRatioTextView.java
@@ -36,6 +36,7 @@ public class AspectRatioTextView extends AppCompatTextView {
 
     private String mAspectRatioTitle;
     private float mAspectRatioX, mAspectRatioY;
+    private boolean mCircle;
 
     public AspectRatioTextView(Context context) {
         this(context, null);
@@ -71,6 +72,7 @@ public class AspectRatioTextView extends AppCompatTextView {
         mAspectRatioTitle = aspectRatio.getAspectRatioTitle();
         mAspectRatioX = aspectRatio.getAspectRatioX();
         mAspectRatioY = aspectRatio.getAspectRatioY();
+        mCircle = aspectRatio.isCircle();
 
         if (mAspectRatioX == CropImageView.SOURCE_IMAGE_ASPECT_RATIO || mAspectRatioY == CropImageView.SOURCE_IMAGE_ASPECT_RATIO) {
             mAspectRatio = CropImageView.SOURCE_IMAGE_ASPECT_RATIO;
@@ -87,6 +89,10 @@ public class AspectRatioTextView extends AppCompatTextView {
             setTitle();
         }
         return mAspectRatio;
+    }
+
+    public boolean isCircle() {
+        return mCircle;
     }
 
     @Override


### PR DESCRIPTION
This allows you to add circle crop as one of the aspect ratio options.

When circle crop is selected/unselected, a protected function on UCropActivity/UCropFragment is called (setCircleCrop) - this allows a subclass to update the crop grid/frame/dimmed layer if so desired. This is also why I've changed some views to be protected rather than private, most importantly mOverlayView.