### PR TITLE
Custom OkHttpClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Currently you can change:
    * choose whether you want rectangle or oval crop area
    * the UI colors (Toolbar, StatusBar, active widget state)
    * and more...
+   
+Since version 2.2.7 in case if you need to change transport protocol, setup timeout etc. You may set your `OkHttpClient` next way:
+
+    ```java
+    new UCropInitializer().setOkHttpClient(client);
+    ``` 
     
 # Compatibility
   

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -38,5 +38,6 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "androidx.core:core:1.1.0"
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
+    implementation "com.squareup.okhttp3:okhttp:3.12.13"
     implementation project(':ucrop')
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".SampleApp"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true"

--- a/sample/src/main/java/com/yalantis/ucrop/sample/SampleApp.java
+++ b/sample/src/main/java/com/yalantis/ucrop/sample/SampleApp.java
@@ -1,0 +1,32 @@
+package com.yalantis.ucrop.sample;
+
+import android.app.Application;
+
+import com.yalantis.ucrop.UCropHttpClientStore;
+
+import java.util.Collections;
+
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+
+public class SampleApp extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        setUcropHttpClient();
+    }
+
+    private void setUcropHttpClient() {
+        ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .allEnabledCipherSuites()
+            .allEnabledTlsVersions()
+            .build();
+
+        OkHttpClient client = new OkHttpClient.Builder()
+            .connectionSpecs(Collections.singletonList(cs))
+            .build();
+
+        UCropHttpClientStore.INSTANCE.setClient(client);
+    }
+}

--- a/sample/src/main/java/com/yalantis/ucrop/sample/SampleApp.java
+++ b/sample/src/main/java/com/yalantis/ucrop/sample/SampleApp.java
@@ -2,7 +2,7 @@ package com.yalantis.ucrop.sample;
 
 import android.app.Application;
 
-import com.yalantis.ucrop.UCropHttpClientStore;
+import com.yalantis.ucrop.UCropInitializer;
 
 import java.util.Collections;
 
@@ -27,6 +27,7 @@ public class SampleApp extends Application {
             .connectionSpecs(Collections.singletonList(cs))
             .build();
 
-        UCropHttpClientStore.INSTANCE.setClient(client);
+        new UCropInitializer()
+            .setOkHttpClient(client);
     }
 }

--- a/ucrop/build.gradle
+++ b/ucrop/build.gradle
@@ -35,5 +35,6 @@ dependencies {
     implementation "androidx.appcompat:appcompat:${androidx_appcompat_version}"
     implementation "androidx.exifinterface:exifinterface:${androidx_exifinterface_version}"
     implementation "androidx.transition:transition:${androidx_transition_version}"
-    implementation "com.squareup.okhttp3:okhttp:3.12.1"
+    // OkHttp3 versions above 3.12.x don't support pre-Lollipop Android versions (API 21)
+    implementation "com.squareup.okhttp3:okhttp:3.12.13"
 }

--- a/ucrop/src/main/java/com/yalantis/ucrop/OkHttpClientStore.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/OkHttpClientStore.java
@@ -4,11 +4,11 @@ import androidx.annotation.NonNull;
 
 import okhttp3.OkHttpClient;
 
-public class UCropHttpClientStore {
+public class OkHttpClientStore {
 
-    private UCropHttpClientStore() {}
+    private OkHttpClientStore() {}
 
-    public final static UCropHttpClientStore INSTANCE = new UCropHttpClientStore();
+    public final static OkHttpClientStore INSTANCE = new OkHttpClientStore();
 
     private OkHttpClient client;
 
@@ -29,7 +29,7 @@ public class UCropHttpClientStore {
      * @param client OkHttpClient for downloading bitmap form remote Uri,
      *               it may contain any preferences you need
      */
-    public void setClient(@NonNull OkHttpClient client) {
+    void setClient(@NonNull OkHttpClient client) {
         this.client = client;
     }
 }

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropHttpClientStore.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropHttpClientStore.java
@@ -1,0 +1,26 @@
+package com.yalantis.ucrop;
+
+import androidx.annotation.NonNull;
+
+import okhttp3.OkHttpClient;
+
+public class UCropHttpClientStore {
+
+    private UCropHttpClientStore() {}
+
+    public final static UCropHttpClientStore INSTANCE = new UCropHttpClientStore();
+
+    private OkHttpClient client;
+
+    @NonNull
+    public OkHttpClient getClient() {
+        if (client == null) {
+            client = new OkHttpClient();
+        }
+        return client;
+    }
+
+    public void setClient(@NonNull OkHttpClient client) {
+        this.client = client;
+    }
+}

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropHttpClientStore.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropHttpClientStore.java
@@ -12,6 +12,11 @@ public class UCropHttpClientStore {
 
     private OkHttpClient client;
 
+    /**
+     * @return stored OkHttpClient if it was already set,
+     *         or just an instance created via empty constructor
+     *         and store it
+     */
     @NonNull
     public OkHttpClient getClient() {
         if (client == null) {
@@ -20,6 +25,10 @@ public class UCropHttpClientStore {
         return client;
     }
 
+    /**
+     * @param client OkHttpClient for downloading bitmap form remote Uri,
+     *               it may contain any preferences you need
+     */
     public void setClient(@NonNull OkHttpClient client) {
         this.client = client;
     }

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropInitializer.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropInitializer.java
@@ -1,0 +1,18 @@
+package com.yalantis.ucrop;
+
+import androidx.annotation.NonNull;
+
+import okhttp3.OkHttpClient;
+
+public class UCropInitializer {
+
+    /**
+     * @param client OkHttpClient for downloading bitmap form remote Uri,
+     *               it may contain any preferences you need
+     */
+    public UCropInitializer setOkHttpClient(@NonNull OkHttpClient client) {
+        OkHttpClientStore.INSTANCE.setClient(client);
+        return this;
+    }
+
+}

--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapLoadTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapLoadTask.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.yalantis.ucrop.UCropHttpClientStore;
 import com.yalantis.ucrop.callback.BitmapLoadCallback;
 import com.yalantis.ucrop.model.ExifInfo;
 import com.yalantis.ucrop.util.BitmapLoadUtils;
@@ -204,15 +205,15 @@ public class BitmapLoadTask extends AsyncTask<Void, Void, BitmapLoadTask.BitmapW
             throw new NullPointerException("Output Uri is null - cannot download image");
         }
 
-        OkHttpClient client = new OkHttpClient();
+        OkHttpClient client = UCropHttpClientStore.INSTANCE.getClient();
 
         BufferedSource source = null;
         Sink sink = null;
         Response response = null;
         try {
             Request request = new Request.Builder()
-                    .url(inputUri.toString())
-                    .build();
+                .url(inputUri.toString())
+                .build();
             response = client.newCall(request).execute();
             source = response.body().source();
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapLoadTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapLoadTask.java
@@ -11,7 +11,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.yalantis.ucrop.UCropHttpClientStore;
+import com.yalantis.ucrop.OkHttpClientStore;
 import com.yalantis.ucrop.callback.BitmapLoadCallback;
 import com.yalantis.ucrop.model.ExifInfo;
 import com.yalantis.ucrop.util.BitmapLoadUtils;
@@ -205,7 +205,7 @@ public class BitmapLoadTask extends AsyncTask<Void, Void, BitmapLoadTask.BitmapW
             throw new NullPointerException("Output Uri is null - cannot download image");
         }
 
-        OkHttpClient client = UCropHttpClientStore.INSTANCE.getClient();
+        OkHttpClient client = OkHttpClientStore.INSTANCE.getClient();
 
         BufferedSource source = null;
         Sink sink = null;


### PR DESCRIPTION
Added ability to set custom `OkHttpClient` for image downloading through `UCropHttpClientStore`.
Updated `okhttp3` dependency for the library.
Added custom `OkHttpClient` for sample app due to outdated random pic url.

**NOTE:** This fix also should be added to the next native release