### PR TITLE
Add UCropActivity to the manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,8 @@
     ``` implementation 'com.github.yalantis:ucrop:2.2.6' ``` - lightweight general solution
     
     ``` implementation 'com.github.yalantis:ucrop:2.2.6-native' ``` - get power of the native code to preserve image quality (+ about 1.5 MB to an apk size)
-    
-2. Add UCropActivity into your AndroidManifest.xml
 
-    ```
-    <activity
-        android:name="com.yalantis.ucrop.UCropActivity"
-        android:screenOrientation="portrait"
-        android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
-    ```
-
-3. The uCrop configuration is created using the builder pattern.
+2. The uCrop configuration is created using the builder pattern.
 
 	```java
     UCrop.of(sourceUri, destinationUri)
@@ -47,7 +38,7 @@
     ```
 
 
-4. Override `onActivityResult` method and handle uCrop result.
+3. Override `onActivityResult` method and handle uCrop result.
 
     ```java
     @Override
@@ -59,7 +50,7 @@
         }
     }
     ```
-5. You may want to add this to your PROGUARD config:
+4. You may want to add this to your PROGUARD config:
 
     ```
     -dontwarn com.yalantis.ucrop**

--- a/ucrop/src/main/AndroidManifest.xml
+++ b/ucrop/src/main/AndroidManifest.xml
@@ -1,2 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.yalantis.ucrop"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.yalantis.ucrop">
+
+    <application>
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+    </application>
+</manifest>


### PR DESCRIPTION
By adding the `UCropActivity` to the manifest, consumers no longer need to add it to their own. If they want to change the appearance/behavior of the activity, they can add it and use `tools:replace` to do so.

This will also help with libraries like [flutter_image_cropper](https://github.com/hnvn/flutter_image_cropper), since they need to explicitly tell consumers to add the `Activity` to the manifest.