### PR TITLE
Fix long image scale bug

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
@@ -469,6 +469,8 @@ public class CropImageView extends TransformImageView {
 
         mMinScale = Math.min(widthScale, heightScale);
         mMaxScale = mMinScale * mMaxScaleMultiplier;
+        float currentScale = getCurrentScale();
+        if (mMaxScale < currentScale) mMaxScale = currentScale;
     }
 
     /**


### PR DESCRIPTION
when  scale a long image smaller, it won't zoom back. I found out the reason is mMaxScale smaller than the original scale value.

this commit fix #817 , and i think #408 looks like the same problem