### PR TITLE
Fix: Use "rwt" file mode for the output image file

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
@@ -40,6 +40,8 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
 
     private static final String CONTENT_SCHEME = "content";
 
+    private static final String WRITE_AND_TRUNCATE = "wt";
+
     private final WeakReference<Context> mContext;
 
     private Bitmap mViewBitmap;
@@ -213,7 +215,7 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
         OutputStream outputStream = null;
         ByteArrayOutputStream outStream = null;
         try {
-            outputStream = context.getContentResolver().openOutputStream(mImageOutputUri);
+            outputStream = context.getContentResolver().openOutputStream(mImageOutputUri, WRITE_AND_TRUNCATE);
             outStream = new ByteArrayOutputStream();
             croppedBitmap.compress(mCompressFormat, mCompressQuality, outStream);
             outputStream.write(outStream.toByteArray());

--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
@@ -40,7 +40,7 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
 
     private static final String CONTENT_SCHEME = "content";
 
-    private static final String WRITE_AND_TRUNCATE = "wt";
+    private static final String READ_WRITE_AND_TRUNCATE = "rwt";
 
     private final WeakReference<Context> mContext;
 
@@ -215,7 +215,7 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
         OutputStream outputStream = null;
         ByteArrayOutputStream outStream = null;
         try {
-            outputStream = context.getContentResolver().openOutputStream(mImageOutputUri, WRITE_AND_TRUNCATE);
+            outputStream = context.getContentResolver().openOutputStream(mImageOutputUri, READ_WRITE_AND_TRUNCATE);
             outStream = new ByteArrayOutputStream();
             croppedBitmap.compress(mCompressFormat, mCompressQuality, outStream);
             outputStream.write(outStream.toByteArray());


### PR DESCRIPTION
Closes #546 

This PR fixes an issue with the output file size. No matter how low the compression quality is set the image will remain its original file size after cropping. 

The default file mode used when opening the `OutputStream` for the `mImageOutputUri` seems to be the culprit. Changing it to `wt` fixed the issue. 

Testing:

Use the sample app and first check the `develop-non-native` branch. 

1. Use `Tmp file destination`
2. Select `Resize image to max size` - set it to a low value like 500
3. Set compression quality to 20
4. Tap `pick & crop`
5. Use JPEG
6. Select an image (big one ideally)
7. Crop the image
8. Once finished use the `Device Explorer` in Android Studio and go to `data/data/com.yalantis.ucrop.sample/cache`
9. Check the size of the file `SampleCropImage.jpg` - compare it with the original

Now check out this branch and repeat the steps above.