### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 	```
 	allprojects {
 	   repositories {
-	      jcenter()
 	      maven { url "https://jitpack.io" }
 	   }
 	}


### PR DESCRIPTION
JCenter was closed on August 15th, 2024. Requests to JCenter will be redirected to Maven Central, but that doesn't seem to be recommended.

https://jfrog.com/blog/jcenter-sunset/