### PR TITLE
Add automated Maven Central publishing via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build and lint
+        run: ./gradlew :ucrop:assembleRelease :ucrop:lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to Maven Central
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Publish to Maven Central
+        run: ./gradlew :ucrop:publish closeAndReleaseStagingRepositories
+        env:
+          ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,23 @@ buildscript {
     }
 }
 
+plugins {
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0' apply false
+}
+
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username = findProperty('nexusUsername') ?: ''
+            password = findProperty('nexusPassword') ?: ''
+        }
+    }
+}
+
 def isReleaseBuild() {
     return version.contains("SNAPSHOT") == false
 }

--- a/mavenpush.gradle
+++ b/mavenpush.gradle
@@ -1,26 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-def sonatypeRepositoryUrl
-if (isReleaseBuild()) {
-    println 'RELEASE BUILD'
-    sonatypeRepositoryUrl = hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-} else {
-    println 'DEBUG BUILD'
-    sonatypeRepositoryUrl = hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-            : "https://oss.sonatype.org/content/repositories/snapshots/"
-}
-
-def getRepositoryUsername() {
-    return hasProperty('nexusUsername') ? nexusUsername : ""
-}
-
-def getRepositoryPassword() {
-    return hasProperty('nexusPassword') ? nexusPassword : ""
-}
-
-
 tasks.register('androidJavadocs', Javadoc) {
     source = android.sourceSets.main.java.sourceFiles
     classpath += project.files(android.getBootClasspath())
@@ -28,26 +8,15 @@ tasks.register('androidJavadocs', Javadoc) {
 
 tasks.register('androidJavadocsJar', Jar) {
     archiveClassifier.set("javadoc")
-    //basename = artifact_id
     from tasks.named('androidJavadocs').get().destinationDir
 }
 
 tasks.register('androidSourcesJar', Jar) {
     archiveClassifier.set("sources")
-    //basename = artifact_id
     from android.sourceSets.main.java.sourceFiles
 }
 
 publishing {
-    repositories {
-        maven {
-            url = sonatypeRepositoryUrl
-            credentials {
-                username = getRepositoryUsername()
-                password = getRepositoryPassword()
-            }
-        }
-    }
     publications {
         maven(MavenPublication) {
             afterEvaluate { project ->
@@ -55,7 +24,6 @@ publishing {
                 if (releaseComponent) {
                     from releaseComponent
                 }
-                artifact tasks.named("bundleReleaseAar")
                 artifact tasks.named('androidSourcesJar').get()
                 artifact tasks.named('androidJavadocsJar').get()
                 version = project.version
@@ -91,9 +59,12 @@ publishing {
     }
 }
 
-
 signing {
     required { isReleaseBuild() && gradle.taskGraph.hasTask("publishing") }
+    def signingInMemoryKey = findProperty('signingInMemoryKey')
+    def signingInMemoryKeyPassword = findProperty('signingInMemoryKeyPassword') ?: ''
+    if (signingInMemoryKey) {
+        useInMemoryPgpKeys(signingInMemoryKey, signingInMemoryKeyPassword)
+    }
     sign publishing.publications.maven
 }
-


### PR DESCRIPTION
## Summary
This PR adds automated publishing to Maven Central, replacing the current
manual/JitPack-only distribution with a fully automated CI/CD pipeline.
Addresses issue #634

## Motivation
The project already has a `mavenpush.gradle` with Sonatype OSSRH configuration,
but no automation around it. This PR wires everything up so that creating a
GitHub Release automatically builds, signs, and publishes to Maven Central —
no manual steps required.
It also migrates from the legacy `oss.sonatype.org` endpoint to the new
**Sonatype Central Portal** (`central.sonatype.com`), which is the current
recommended approach as OSSRH is being sunset.

## Changes
### New files
- `.github/workflows/ci.yml` — builds and lints the `:ucrop` module on every
  push and pull request to `master`/`main`
- `.github/workflows/publish.yml` — publishes to Maven Central automatically
  when a GitHub Release is created
### Modified files
- `build.gradle` — adds the
  [`gradle-nexus/publish-plugin`](https://github.com/gradle-nexus/publish-plugin)
  (v2.0.0), configured to target the new Central Portal OSSRH Staging API
  endpoint; this enables fully automated staging close and release
- `mavenpush.gradle` — three improvements:
  - Removes the `repositories` block (now managed by the nexus publish plugin)
  - Fixes a duplicate AAR artifact issue (`bundleReleaseAar` was declared
    alongside `from components.release`, which already includes it)
  - Adds in-memory GPG signing support so that signing works in CI without a
    local GPG keyring

## Required setup (one-time, by repo maintainer)
Before the publish workflow can run, the following must be configured:

**1. Register on Sonatype Central Portal**
Sign in at https://central.sonatype.com and verify the `com.yalantis` namespace
is claimed under your account.
**2. Generate a Portal Token**
Go to Account → Generate User Token. This produces a new username/password pair
(distinct from old OSSRH credentials).
**3. Add GitHub Repository Secrets**
In Settings → Secrets and variables → Actions, add:
| Secret | Value |
|--------|-------|
| `OSSRH_USERNAME` | Portal token username |
| `OSSRH_PASSWORD` | Portal token password |
| `SIGNING_KEY` | ASCII-armored GPG private key: `gpg --armor --export-secret-keys YOUR_KEY_ID` |
| `SIGNING_PASSWORD` | GPG key passphrase |

## Publishing a release
1. Create a GitHub Release (e.g. tag `v2.2.12`)
2. The `publish` workflow triggers automatically
3. Artifacts are built, signed, uploaded to Central Portal staging, and
   released to Maven Central without any manual intervention
4. Monitor progress at https://central.sonatype.com/publishing/deployments

## Testing
The CI workflow (`ci.yml`) runs on this PR to validate the build and lint
checks pass.
